### PR TITLE
Fix for Sybase

### DIFF
--- a/ext/tiny_tds/client.c
+++ b/ext/tiny_tds/client.c
@@ -96,7 +96,7 @@ int tinytds_err_handler(DBPROCESS *dbproc, int severity, int dberr, int oserr, c
 
 int tinytds_msg_handler(DBPROCESS *dbproc, DBINT msgno, int msgstate, int severity, char *msgtext, char *srvname, char *procname, int line) {
   static char *source = "message";
-  if (severity)
+  if (severity > 10)
     rb_tinytds_raise_error(dbproc, 1, msgtext, source, severity, msgno, msgstate);
   return 0;
 }


### PR DESCRIPTION
This allows TinyTDS to work with Sybase. Sybase sends a message with
severity 10 anytime the database changes. This includes first connect which
makes TinyTDS completely unusable.

Allowing severity level 10 to not throw errors should be ok as documented
here:

http://www.freetds.org/userguide/samplecode.htm
