### PR TITLE
Adding Query Option :include_empty_sets

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -202,6 +202,7 @@ Every TinyTds::Result object can pass query options to the #each method. The def
 * :symbolize_keys => false - Row hash keys. Defaults to shared/frozen string keys.
 * :cache_rows => true - Successive calls to #each returns the cached rows.
 * :timezone => :local - Local to the ruby client or :utc for UTC.
+* :include_empty_sets => false - Also include empty results set in queries that return multiple result sets
 
 Each result gets a copy of the default options you specify at the client level and can be overridden by passing an options hash to the #each method. For example
   

--- a/ext/tiny_tds/result.c
+++ b/ext/tiny_tds/result.c
@@ -8,7 +8,7 @@ VALUE opt_decimal_zero, opt_float_zero, opt_one, opt_zero, opt_four, opt_19hdr, 
 int   opt_ruby_186;
 static ID intern_new, intern_utc, intern_local, intern_localtime, intern_merge, 
           intern_civil, intern_new_offset, intern_plus, intern_divide, intern_Rational;
-static ID sym_symbolize_keys, sym_as, sym_array, sym_cache_rows, sym_first, sym_timezone, sym_local, sym_utc;
+static ID sym_symbolize_keys, sym_as, sym_array, sym_cache_rows, sym_first, sym_timezone, sym_local, sym_utc, sym_include_empty_sets;
 
 
 // Lib Macros
@@ -292,7 +292,7 @@ static VALUE rb_tinytds_result_each(int argc, VALUE * argv, VALUE self) {
   /* Local Vars */
   VALUE qopts, opts, block;
   ID timezone;
-  int symbolize_keys = 0, as_array = 0, cache_rows = 0, first = 0;
+  int symbolize_keys = 0, as_array = 0, cache_rows = 0, first = 0, include_empty_sets = 0;
   /* Merge Options Hash To Query Options. Populate Opts & Block Var. */
   qopts = rb_iv_get(self, "@query_options");
   if (rb_scan_args(argc, argv, "01&", &opts, &block) == 1)
@@ -315,13 +315,16 @@ static VALUE rb_tinytds_result_each(int argc, VALUE * argv, VALUE self) {
     rb_warn(":timezone option must be :utc or :local - defaulting to :local");
     timezone = intern_local;
   }
+  if (rb_hash_aref(qopts, sym_include_empty_sets) == Qtrue )
+    include_empty_sets = 1;
+
   /* Make The Results Or Yield Existing */
   if (NIL_P(rwrap->results)) {
     rwrap->results = rb_ary_new();
     RETCODE dbsqlok_rc = rb_tinytds_result_ok_helper(rwrap->client);
     RETCODE dbresults_rc = rb_tinytds_result_dbresults_retcode(self);
     while ((dbsqlok_rc == SUCCEED) && (dbresults_rc == SUCCEED)) {
-      int has_rows = (DBROWS(rwrap->client) == SUCCEED) ? 1 : 0;
+      int has_rows = ( include_empty_sets || (DBROWS(rwrap->client) == SUCCEED) ) ? 1 : 0;
       rb_tinytds_result_fields(self);
       if (has_rows && rwrap->number_of_fields > 0) {
         /* Create rows for this result set. */
@@ -473,6 +476,7 @@ void init_tinytds_result() {
   sym_local = ID2SYM(intern_local);
   sym_utc = ID2SYM(intern_utc);
   sym_timezone = ID2SYM(rb_intern("timezone"));
+  sym_include_empty_sets = ID2SYM(rb_intern("include_empty_sets"));
   /* Data Conversion Options */
   opt_decimal_zero = rb_str_new2("0.0");
   rb_global_variable(&opt_decimal_zero);


### PR DESCRIPTION
When using multiple result sets also empty sets are returned.

As discussed in #29
