### PR TITLE
UpdateCopy mysql2s handling of Time and Datetime

### DIFF
--- a/ext/tiny_tds/result.c
+++ b/ext/tiny_tds/result.c
@@ -1,6 +1,48 @@
 
 #include <tiny_tds_ext.h>
 
+#if (SIZEOF_INT < SIZEOF_LONG) || defined(HAVE_RUBY_ENCODING_H)
+/* on 64bit platforms we can handle dates way outside 2038-01-19T03:14:07
+ *
+ * (10000*31557600) + (12*2592000) + (31*86400) + (11*3600) + (59*60) + 59
+ */
+#define TINY_TDS_MAX_TIME 315607276799ULL
+#else
+/**
+ * On 32bit platforms the maximum date the Time class can handle is 2038-01-19T03:14:07
+ * 2038 years + 1 month + 19 days + 3 hours + 14 minutes + 7 seconds = 64318634047 seconds
+ *
+ * (2038*31557600) + (1*2592000) + (19*86400) + (3*3600) + (14*60) + 7
+ */
+#define TINY_TDS_MAX_TIME 64318634047ULL
+#endif
+
+#if defined(HAVE_RUBY_ENCODING_H)
+/* 0000-1-1 00:00:00 UTC
+ *
+ * (0*31557600) + (1*2592000) + (1*86400) + (0*3600) + (0*60) + 0
+ */
+#define TINY_TDS_MIN_TIME 2678400ULL
+#elif SIZEOF_INT < SIZEOF_LONG // 64bit Ruby 1.8
+/* 0139-1-1 00:00:00 UTC
+ *
+ * (139*31557600) + (1*2592000) + (1*86400) + (0*3600) + (0*60) + 0
+ */
+#define TINY_TDS_MIN_TIME 4389184800ULL
+#elif defined(NEGATIVE_TIME_T)
+/* 1901-12-13 20:45:52 UTC : The oldest time in 32-bit signed time_t.
+ *
+ * (1901*31557600) + (12*2592000) + (13*86400) + (20*3600) + (45*60) + 52
+ */
+#define TINY_TDS_MIN_TIME 60023299552ULL
+#else
+/* 1970-01-01 00:00:01 UTC : The Unix epoch - the oldest time in portable time_t.
+ *
+ * (1970*31557600) + (1*2592000) + (1*86400) + (0*3600) + (0*60) + 1
+ */
+#define TINY_TDS_MIN_TIME 62171150401ULL
+#endif
+
 VALUE cTinyTdsResult;
 extern VALUE mTinyTds, cTinyTdsClient, cTinyTdsError;
 VALUE cBigDecimal, cDate, cDateTime;
@@ -198,10 +240,11 @@ static VALUE rb_tinytds_result_fetch_row(VALUE self, ID timezone, int symbolize_
               min   = date_rec.dateminute,
               sec   = date_rec.datesecond,
               msec  = date_rec.datemsecond;
+          uint64_t seconds = (year*31557600ULL) + (month*2592000ULL) + (day*86400ULL) + (hour*3600ULL) + (min*60ULL) + sec;    
           if (year+month+day+hour+min+sec+msec != 0) {
             VALUE offset = (timezone == intern_local) ? rwrap->local_offset : opt_zero;
             /* Use DateTime */
-            if (year < 1902 || year+month+day > 2058) {
+            if (seconds < TINY_TDS_MIN_TIME || seconds > TINY_TDS_MAX_TIME) {
               VALUE datetime_sec = INT2NUM(sec);
               if (msec != 0) {
                 if ((opt_ruby_186 == 1 && sec < 59) || (opt_ruby_186 != 1)) {

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -39,40 +39,77 @@ class SchemaTest < TinyTds::TestCase
       end
       
       should 'cast datetime' do
-        # 1753-01-01T00:00:00.000
-        v = find_value 61, :datetime
-        assert_instance_of DateTime, v, 'not in range of Time class'
-        assert_equal 1753, v.year
-        assert_equal 01, v.month
-        assert_equal 01, v.day
-        assert_equal 0, v.hour
-        assert_equal 0, v.min
-        assert_equal 0, v.sec
-        assert_equal 0, v.usec
-        # 9999-12-31T23:59:59.997
-        v = find_value 62, :datetime
-        assert_instance_of DateTime, v, 'not in range of Time class'
-        assert_equal 9999, v.year
-        assert_equal 12, v.month
-        assert_equal 31, v.day
-        assert_equal 23, v.hour
-        assert_equal 59, v.min
-        assert_equal 59, v.sec
-        assert_equal 997000, v.usec unless ruby186?
-        assert_equal local_offset, find_value(61, :datetime, :timezone => :local).offset
-        assert_equal 0, find_value(61, :datetime, :timezone => :utc).offset
-        # 2010-01-01T12:34:56.123
-        v = find_value 63, :datetime
-        assert_instance_of Time, v, 'in range of Time class'
-        assert_equal 2010, v.year
-        assert_equal 01, v.month
-        assert_equal 01, v.day
-        assert_equal 12, v.hour
-        assert_equal 34, v.min
-        assert_equal 56, v.sec
-        assert_equal 123000, v.usec
-        assert_equal utc_offset, find_value(63, :datetime, :timezone => :local).utc_offset
-        assert_equal 0, find_value(63, :datetime, :timezone => :utc).utc_offset
+        if ruby18? && 1.size == 4 #32 bit
+          # 1753-01-01T00:00:00.000
+          v = find_value 61, :datetime
+          assert_instance_of DateTime, v, 'not in range of Time class'
+          assert_equal 1753, v.year
+          assert_equal 01, v.month
+          assert_equal 01, v.day
+          assert_equal 0, v.hour
+          assert_equal 0, v.min
+          assert_equal 0, v.sec
+          assert_equal 0, v.usec
+          # 9999-12-31T23:59:59.997
+          v = find_value 62, :datetime
+          assert_instance_of DateTime, v, 'not in range of Time class'
+          assert_equal 9999, v.year
+          assert_equal 12, v.month
+          assert_equal 31, v.day
+          assert_equal 23, v.hour
+          assert_equal 59, v.min
+          assert_equal 59, v.sec
+          assert_equal 997000, v.usec unless ruby186?
+          assert_equal local_offset, find_value(62, :datetime, :timezone => :local).offset
+          assert_equal 0, find_value(62, :datetime, :timezone => :utc).offset
+          # 2010-01-01T12:34:56.123
+          v = find_value 63, :datetime
+          assert_instance_of Time, v, 'in range of Time class'
+          assert_equal 2010, v.year
+          assert_equal 01, v.month
+          assert_equal 01, v.day
+          assert_equal 12, v.hour
+          assert_equal 34, v.min
+          assert_equal 56, v.sec
+          assert_equal 123000, v.usec
+          assert_equal utc_offset, find_value(63, :datetime, :timezone => :local).utc_offset
+          assert_equal 0, find_value(63, :datetime, :timezone => :utc).utc_offset
+        else
+          # 1753-01-01T00:00:00.000
+          v = find_value 61, :datetime
+          assert_instance_of Time, v, 'not in range of Time class'
+          assert_equal 1753, v.year
+          assert_equal 01, v.month
+          assert_equal 01, v.day
+          assert_equal 0, v.hour
+          assert_equal 0, v.min
+          assert_equal 0, v.sec
+          assert_equal 0, v.usec
+          # 9999-12-31T23:59:59.997
+          v = find_value 62, :datetime
+          assert_instance_of Time, v, 'not in range of Time class'
+          assert_equal 9999, v.year
+          assert_equal 12, v.month
+          assert_equal 31, v.day
+          assert_equal 23, v.hour
+          assert_equal 59, v.min
+          assert_equal 59, v.sec
+          assert_equal 997000, v.usec unless ruby186?
+          assert_equal utc_offset, find_value(62, :datetime, :timezone => :local).utc_offset
+          assert_equal 0, find_value(62, :datetime, :timezone => :utc).utc_offset
+          # 2010-01-01T12:34:56.123
+          v = find_value 63, :datetime
+          assert_instance_of Time, v, 'in range of Time class'
+          assert_equal 2010, v.year
+          assert_equal 01, v.month
+          assert_equal 01, v.day
+          assert_equal 12, v.hour
+          assert_equal 34, v.min
+          assert_equal 56, v.sec
+          assert_equal 123000, v.usec
+          assert_equal utc_offset, find_value(63, :datetime, :timezone => :local).utc_offset
+          assert_equal 0, find_value(63, :datetime, :timezone => :utc).utc_offset
+        end
       end
       
       should 'cast decimal' do
@@ -146,28 +183,53 @@ class SchemaTest < TinyTds::TestCase
       end
       
       should 'cast smalldatetime' do
-        # 1901-01-01 15:45:00
-        v = find_value 231, :smalldatetime
-        assert_instance_of DateTime, v
-        assert_equal 1901, v.year
-        assert_equal 01, v.month
-        assert_equal 01, v.day
-        assert_equal 15, v.hour
-        assert_equal 45, v.min
-        assert_equal 00, v.sec
-        assert_equal local_offset, find_value(231, :smalldatetime, :timezone => :local).offset
-        assert_equal 0, find_value(231, :smalldatetime, :timezone => :utc).offset
-        # 2078-06-05 04:20:00
-        v = find_value 232, :smalldatetime
-        assert_instance_of DateTime, v
-        assert_equal 2078, v.year
-        assert_equal 06, v.month
-        assert_equal 05, v.day
-        assert_equal 04, v.hour
-        assert_equal 20, v.min
-        assert_equal 00, v.sec
-        assert_equal local_offset, find_value(232, :smalldatetime, :timezone => :local).offset
-        assert_equal 0, find_value(232, :smalldatetime, :timezone => :utc).offset
+        if ruby18? && 1.size == 4 #32 bit        
+          # 1901-01-01 15:45:00
+          v = find_value 231, :smalldatetime
+          assert_instance_of DateTime, v
+          assert_equal 1901, v.year
+          assert_equal 01, v.month
+          assert_equal 01, v.day
+          assert_equal 15, v.hour
+          assert_equal 45, v.min
+          assert_equal 00, v.sec
+          assert_equal local_offset, find_value(231, :smalldatetime, :timezone => :local).offset
+          assert_equal 0, find_value(231, :smalldatetime, :timezone => :utc).offset
+          # 2078-06-05 04:20:00
+          v = find_value 232, :smalldatetime
+          assert_instance_of DateTime, v
+          assert_equal 2078, v.year
+          assert_equal 06, v.month
+          assert_equal 05, v.day
+          assert_equal 04, v.hour
+          assert_equal 20, v.min
+          assert_equal 00, v.sec
+          assert_equal local_offset, find_value(232, :smalldatetime, :timezone => :local).offset
+          assert_equal 0, find_value(232, :smalldatetime, :timezone => :utc).offset
+        else
+          # 1901-01-01 15:45:00
+          v = find_value 231, :smalldatetime
+          assert_instance_of Time, v
+          assert_equal 1901, v.year
+          assert_equal 01, v.month
+          assert_equal 01, v.day
+          assert_equal 15, v.hour
+          assert_equal 45, v.min
+          assert_equal 00, v.sec
+          assert_equal Time.local(1901).utc_offset, find_value(231, :smalldatetime, :timezone => :local).utc_offset
+          assert_equal 0, find_value(231, :smalldatetime, :timezone => :utc).utc_offset
+          # 2078-06-05 04:20:00
+          v = find_value 232, :smalldatetime
+          assert_instance_of Time, v
+          assert_equal 2078, v.year
+          assert_equal 06, v.month
+          assert_equal 05, v.day
+          assert_equal 04, v.hour
+          assert_equal 20, v.min
+          assert_equal 00, v.sec
+          assert_equal Time.local(2078,6).utc_offset, find_value(232, :smalldatetime, :timezone => :local).utc_offset
+          assert_equal 0, find_value(232, :smalldatetime, :timezone => :utc).utc_offset
+        end
       end
       
       should 'cast smallint' do


### PR DESCRIPTION
Copy mysql2s handling of using Time vs DateTime for casting datetime columns.

I have tested under ruby 1.8.7 and 1.9.2 on both 32bit and 64bit systems. However, on Rubinius on a 64 bit system casts to Time when it should be DateTime because SIZEOF_INT and SIZEOF_LONG aren't available. Mysql2 is currently incompatible with Rubinius.
