### PR TITLE
Convert password option to string

### DIFF
--- a/lib/tiny_tds/client.rb
+++ b/lib/tiny_tds/client.rb
@@ -54,7 +54,8 @@ module TinyTds
 
 
     def initialize(opts={})
-      warn 'FreeTDS may have issues with passwords longer than 30 characters!' if opts[:password].to_s.length > 30
+      opts[:password] = opts[:password].to_s
+      warn 'FreeTDS may have issues with passwords longer than 30 characters!' if opts[:password].length > 30
       raise ArgumentError, 'missing :username option' if opts[:username].to_s.empty?
       raise ArgumentError, 'missing :host option if no :dataserver given' if opts[:dataserver].to_s.empty? && opts[:host].to_s.empty?
       @query_options = @@default_query_options.dup


### PR DESCRIPTION
This allow using digit-only passwords without quotation. The error message with digit-only passwords is not very helpful, so it is hard to understand what is wrong: rails-sqlserver/activerecord-sqlserver-adapter#232
