### PR TITLE
Support an optional environment variable to find FreeTDS.

### DIFF
--- a/ext/tiny_tds/extconf.rb
+++ b/ext/tiny_tds/extconf.rb
@@ -6,8 +6,17 @@ require 'mkmf'
 
 # Shamelessly copied from nokogiri
 #
-LIBDIR     = RbConfig::CONFIG['libdir']
-INCLUDEDIR = RbConfig::CONFIG['includedir']
+
+FREETDSDIR = ENV['FREETDS_DIR']
+
+if FREETDSDIR.nil? || FREETDSDIR.empty?
+  LIBDIR     = RbConfig::CONFIG['libdir']
+  INCLUDEDIR = RbConfig::CONFIG['includedir']
+else
+  puts "Will use #{FREETDSDIR}"
+  LIBDIR = "#{FREETDSDIR}/lib"
+  INCLUDEDIR = "#{FREETDSDIR}/include"
+end
 
 $CFLAGS  << " #{ENV["CFLAGS"]}"
 $LDFLAGS << " #{ENV["LDFLAGS"]}"


### PR DESCRIPTION
Hey there,

I don't know if this small tweak is useful to you, but it is something I had to do to get this gem to install on Heroku successfully.

It made sense to have extconfig check if a FREETDS_DIR was set in the environment, and use its value if set, instead of just going with libdir and includedir config always.

Thanks!
