### PR TITLE
Allow Support for 31+ Character Usernames/Passwords

### DIFF
--- a/ext/tiny_tds/client.c
+++ b/ext/tiny_tds/client.c
@@ -264,14 +264,14 @@ static VALUE rb_tinytds_connect(VALUE self, VALUE opts) {
   dbmsghandle(tinytds_msg_handler);
   GET_CLIENT_WRAPPER(self);
   cwrap->login = dblogin();
+  if (!NIL_P(version))
+    dbsetlversion(cwrap->login, NUM2INT(version));
   if (!NIL_P(user))
     dbsetluser(cwrap->login, StringValuePtr(user));
   if (!NIL_P(pass))
     dbsetlpwd(cwrap->login, StringValuePtr(pass));
   if (!NIL_P(app))
     dbsetlapp(cwrap->login, StringValuePtr(app));
-  if (!NIL_P(version))
-    dbsetlversion(cwrap->login, NUM2INT(version));
   if (!NIL_P(ltimeout))
     dbsetlogintime(NUM2INT(ltimeout));
   if (!NIL_P(timeout))


### PR DESCRIPTION
This patch makes a simple change to the client initialization that allows for use with our patched version of FreeTDS (https://github.com/veracross/freetds) to properly handle logins for users with 31+ character usernames or passwords.

Currently in FreeTDS there is an arbitrary restriction that usernames and passwords may not be more than 30 characters long. This is due to the old TDS 4.2 and 5.0 login packet structure. http://freetds.schemamania.org/tds.html#login

With the TDS 7.0+ login packet, arbitrary length usernames and passwords are supported. http://freetds.schemamania.org/tds.html#login7

Via a very simple patch to FreeTDS (https://github.com/veracross/freetds/commit/f403ab9a985b9b84ebbb647464f5a664668abe62), we remove the unnecessary length restriction when working with the TDS protocol 7.0+.

This change to TinyTds is necessary so that the correct protocol version information is set when the username and password are checked.
