### PR TITLE
#138 Change in behavior for Azure SQL on SYBETIME(20003) errors, don't c...

### DIFF
--- a/ext/tiny_tds/client.h
+++ b/ext/tiny_tds/client.h
@@ -23,6 +23,7 @@ typedef struct {
   short int dbcancel_sent;
   short int nonblocking;
   tinytds_errordata nonblocking_error;
+  short int continue_on_timeout; 
 } tinytds_client_userdata;
 
 typedef struct {


### PR DESCRIPTION
#138 Change in behavior for Azure SQL on SYBETIME(20003) errors, don't continue to use the connection. Return INT_EXIT instead.

Tested against Azure Sql using an existing application. Not unit tested using rake. 
