### PR TITLE
Make first work like expected

### DIFF
--- a/lib/tiny_tds/result.rb
+++ b/lib/tiny_tds/result.rb
@@ -3,6 +3,8 @@ module TinyTds
     
     include Enumerable
     
-    
+    def first
+      each(first: true).first
+    end
   end
 end

--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -45,6 +45,13 @@ class ResultTest < TinyTds::TestCase
       assert_equal data.first.object_id, result.each.first.object_id
     end
     
+    it 'allows successive call to each after first' do
+      result = @client.execute(@query1)
+      first = result.first
+      data = result.each
+      assert_equal first.object_id, data.first.object_id
+    end
+    
     it 'returns hashes with string keys' do
       result = @client.execute(@query1)
       row = result.each(:as => :hash, :symbolize_keys => false).first


### PR DESCRIPTION
It took me quite a while to get that first wasn't working like expected for queries with multiple resutls. I got a
`Attempt to initiate a new Adaptive Server operation with results pending (TinyTds::Error)`
Probably I should do a `cancel` after, but than I have to save the result in a variable which makes it less expressive.

Next to that I found out that you could not run `each` after you ran `first`. To make the Result object to behave more like an Enumerable I propose this change which also improves performance compared to what `first` does now.