### PR TITLE
Revert 999fa571 so timeouts do not kill the client.

### DIFF
--- a/ext/tiny_tds/client.c
+++ b/ext/tiny_tds/client.c
@@ -73,9 +73,9 @@ int tinytds_err_handler(DBPROCESS *dbproc, int severity, int dberr, int oserr, c
       /*
       SYBETIME is the only error that can send INT_TIMEOUT or INT_CONTINUE,
       but we don't ever want to automatically retry. Instead have the app
-      decide what to do. We would use INT_TIMEOUT, however it seems tdserror()
-      in tds/util.c converts INT_TIMEOUT to INT_CONTINUE.
+      decide what to do.
       */
+      return_value = INT_TIMEOUT;
       cancel = 1;
       break;
 


### PR DESCRIPTION
This reverts commit 999fa571. In the `tinytds_err_handler` @wbond made [this commit](http://git.io/T7LY4g) recently and noted that the tds/util.c converted `INT_TIMEOUT` to `INT_CONTINUE`. here is the code in the `tdserror` function the commit speaks to.

``` c
if (rc == TDS_INT_TIMEOUT) {
  tds_send_cancel(tds);
  rc = TDS_INT_CONTINUE;
}
```

This has been here since [this FreeTDS refactor commit](https://gitorious.org/freetds/ramiros-freetds/commit/7bcb28a) see last lines. Love the commit message.

Because of this change, the `raises TinyTds exception with long query past :timeout option` test fails with a `TinyTds::Error: DBPROCESS is dead or not enabled` message. Here is a code snippet that excercises the test code as it is now.

``` ruby
require 'tiny_tds'
client = TinyTds::Client.new timeout: 1, username: 'tinytds', host: 'ss2008'

client.execute("WaitFor Delay '00:00:02'").do
  => TinyTds::Error: Adaptive Server connection timed out
client.closed? # => false
client.dead?   # => true
client.execute("SELECT 1 AS [count]").to_a.first
  => TinyTds::Error: DBPROCESS is dead or not enabled
```

After this revert commit, the behavior will be.

``` ruby
client.execute("WaitFor Delay '00:00:02'").do
  => TinyTds::Error: Adaptive Server connection timed out
client.closed? # => false
client.dead?   # => false
client.execute("SELECT 1 AS [count]").to_a.first
  => {"count"=>1}
```

@wbond, can you talk a little bit about why we removed `return_value = INT_TIMEOUT` in that commit. Did it help something else? If so, I think we should keep it and handle it differently? I just need to know a little more.
