### PR TITLE
[WIP] Fix Compile Warnings

### DIFF
--- a/ext/tiny_tds/client.c
+++ b/ext/tiny_tds/client.c
@@ -4,7 +4,6 @@
 VALUE cTinyTdsClient;
 extern VALUE mTinyTds, cTinyTdsError;
 static ID sym_username, sym_password, sym_dataserver, sym_database, sym_appname, sym_tds_version, sym_login_timeout, sym_timeout, sym_encoding, sym_azure;
-static ID intern_source_eql, intern_severity_eql, intern_db_error_number_eql, intern_os_error_number_eql;
 static ID intern_new, intern_dup, intern_transpose_iconv_encoding, intern_local_offset, intern_gsub;
 VALUE opt_escape_regex, opt_escape_dblquote;
 
@@ -20,29 +19,6 @@ VALUE opt_escape_regex, opt_escape_dblquote;
     rb_raise(cTinyTdsError, "closed connection"); \
     return Qnil; \
   }
-
-
-// Lib Backend (Helpers)
-
-VALUE rb_tinytds_raise_error(DBPROCESS *dbproc, int cancel, char *error, char *source, int severity, int dberr, int oserr) {
-  GET_CLIENT_USERDATA(dbproc);
-  if (cancel && !dbdead(dbproc) && userdata && !userdata->closed) {
-    userdata->dbsqlok_sent = 1;
-    dbsqlok(dbproc);
-    userdata->dbcancel_sent = 1;
-    dbcancel(dbproc);
-  }
-  VALUE e = rb_exc_new2(cTinyTdsError, error);
-  rb_funcall(e, intern_source_eql, 1, rb_str_new2(source));
-  if (severity)
-    rb_funcall(e, intern_severity_eql, 1, INT2FIX(severity));
-  if (dberr)
-    rb_funcall(e, intern_db_error_number_eql, 1, INT2FIX(dberr));
-  if (oserr)
-    rb_funcall(e, intern_os_error_number_eql, 1, INT2FIX(oserr));
-  rb_exc_raise(e);
-  return Qnil;
-}
 
 
 // Lib Backend (Memory Management & Handlers)
@@ -389,11 +365,6 @@ void init_tinytds_client() {
   sym_timeout = ID2SYM(rb_intern("timeout"));
   sym_encoding = ID2SYM(rb_intern("encoding"));
   sym_azure = ID2SYM(rb_intern("azure"));
-  /* Intern TinyTds::Error Accessors */
-  intern_source_eql = rb_intern("source=");
-  intern_severity_eql = rb_intern("severity=");
-  intern_db_error_number_eql = rb_intern("db_error_number=");
-  intern_os_error_number_eql = rb_intern("os_error_number=");
   /* Intern Misc */
   intern_new = rb_intern("new");
   intern_dup = rb_intern("dup");

--- a/ext/tiny_tds/client.h
+++ b/ext/tiny_tds/client.h
@@ -7,8 +7,8 @@ void init_tinytds_client();
 typedef struct {
   short int is_set;
   int cancel;
-  char error[1024];
-  char source[1024];
+  char *error;
+  char *source;
   int severity;
   int dberr;
   int oserr;

--- a/ext/tiny_tds/error.c
+++ b/ext/tiny_tds/error.c
@@ -1,0 +1,39 @@
+
+#include <tiny_tds_ext.h>
+
+extern VALUE cTinyTdsError;
+static ID intern_source_eql, intern_severity_eql, intern_db_error_number_eql, intern_os_error_number_eql;
+
+VALUE rb_tinytds_raise_error(DBPROCESS *dbproc, int cancel, char *error, char *source, int severity, int dberr, int oserr) {
+  intern_source_eql = rb_intern("source=");
+  intern_severity_eql = rb_intern("severity=");
+  intern_db_error_number_eql = rb_intern("db_error_number=");
+  intern_os_error_number_eql = rb_intern("os_error_number=");
+  GET_CLIENT_USERDATA(dbproc);
+  if (cancel && !dbdead(dbproc) && userdata && !userdata->closed) {
+    userdata->dbsqlok_sent = 1;
+    dbsqlok(dbproc);
+    userdata->dbcancel_sent = 1;
+    dbcancel(dbproc);
+  }
+  VALUE e = rb_exc_new2(cTinyTdsError, error);
+  rb_funcall(e, intern_source_eql, 1, rb_str_new2(source));
+  if (severity)
+    rb_funcall(e, intern_severity_eql, 1, INT2FIX(severity));
+  if (dberr)
+    rb_funcall(e, intern_db_error_number_eql, 1, INT2FIX(dberr));
+  if (oserr)
+    rb_funcall(e, intern_os_error_number_eql, 1, INT2FIX(oserr));
+  rb_exc_raise(e);
+  return Qnil;
+}
+
+
+// Lib Init
+
+void init_tinytds_error() {
+  intern_source_eql = rb_intern("source=");
+  intern_severity_eql = rb_intern("severity=");
+  intern_db_error_number_eql = rb_intern("db_error_number=");
+  intern_os_error_number_eql = rb_intern("os_error_number=");
+}

--- a/ext/tiny_tds/error.h
+++ b/ext/tiny_tds/error.h
@@ -1,0 +1,11 @@
+
+#ifndef TINYTDS_ERROR_H
+#define TINYTDS_ERROR_H
+
+static ID intern_source_eql, intern_severity_eql, intern_db_error_number_eql, intern_os_error_number_eql;
+
+void init_tinytds_error();
+VALUE rb_tinytds_raise_error(DBPROCESS *dbproc, int cancel, char *error, char *source, int severity, int dberr, int oserr);
+
+
+#endif

--- a/ext/tiny_tds/result.c
+++ b/ext/tiny_tds/result.c
@@ -94,8 +94,8 @@ static void nogvl_cleanup(DBPROCESS *client) {
     userdata->nonblocking_error.is_set = 0;
     rb_tinytds_raise_error(client,
       userdata->nonblocking_error.cancel,
-      &userdata->nonblocking_error.error,
-      &userdata->nonblocking_error.source,
+      userdata->nonblocking_error.error,
+      userdata->nonblocking_error.source,
       userdata->nonblocking_error.severity,
       userdata->nonblocking_error.dberr,
       userdata->nonblocking_error.oserr);

--- a/ext/tiny_tds/tiny_tds_ext.c
+++ b/ext/tiny_tds/tiny_tds_ext.c
@@ -6,6 +6,7 @@ VALUE mTinyTds, cTinyTdsError;
 void Init_tiny_tds() {
   mTinyTds      = rb_define_module("TinyTds");
   cTinyTdsError = rb_const_get(mTinyTds, rb_intern("Error"));
+  init_tinytds_error();
   init_tinytds_client();
   init_tinytds_result();
 }

--- a/ext/tiny_tds/tiny_tds_ext.h
+++ b/ext/tiny_tds/tiny_tds_ext.h
@@ -6,6 +6,7 @@
 
 #include <ruby.h>
 #include <ruby/encoding.h>
+#include <ruby/thread.h>
 #include <sybfront.h>
 #include <sybdb.h>
 

--- a/ext/tiny_tds/tiny_tds_ext.h
+++ b/ext/tiny_tds/tiny_tds_ext.h
@@ -10,7 +10,8 @@
 #include <sybfront.h>
 #include <sybdb.h>
 
-#include <client.h>
-#include <result.h>
+#include <./error.h>
+#include <./client.h>
+#include <./result.h>
 
 #endif


### PR DESCRIPTION
I need some help with this please. I want to fix all the local and appveyor compiler warnings. However, my second commit 97353260 to fix the `implicit declaration of function 'rb_tinytds_raise_error'` opened up some new warnings WRT to `NOGVL_DBCALL` function parameters and return type (I think). 

This causes segmentation faults now perhaps related to string copies in that fix? Can someone take a look over that commit and give me some feedback?