### PR TITLE
Fix compiler warnings

### DIFF
--- a/ext/tiny_tds/client.h
+++ b/ext/tiny_tds/client.h
@@ -36,6 +36,7 @@ typedef struct {
   rb_encoding *encoding;
 } tinytds_client_wrapper;
 
+VALUE rb_tinytds_raise_error(DBPROCESS *dbproc, int cancel, char *error, char *source, int severity, int dberr, int oserr);
 
 // Lib Macros
 

--- a/ext/tiny_tds/result.c
+++ b/ext/tiny_tds/result.c
@@ -68,7 +68,7 @@ VALUE rb_tinytds_new_result_obj(tinytds_client_wrapper *cwrap) {
 
 #define NOGVL_DBCALL(_dbfunction, _client) ( \
   (RETCODE)rb_thread_call_without_gvl( \
-    (rb_blocking_function_t*)_dbfunction, _client, \
+    (void *(*)(void *))_dbfunction, _client, \
     (rb_unblock_function_t*)dbcancel_ubf, _client ) \
 )
 
@@ -94,8 +94,8 @@ static void nogvl_cleanup(DBPROCESS *client) {
     userdata->nonblocking_error.is_set = 0;
     rb_tinytds_raise_error(client,
       userdata->nonblocking_error.cancel,
-      &userdata->nonblocking_error.error,
-      &userdata->nonblocking_error.source,
+      userdata->nonblocking_error.error,
+      userdata->nonblocking_error.source,
       userdata->nonblocking_error.severity,
       userdata->nonblocking_error.dberr,
       userdata->nonblocking_error.oserr);

--- a/ext/tiny_tds/tiny_tds_ext.h
+++ b/ext/tiny_tds/tiny_tds_ext.h
@@ -6,6 +6,7 @@
 
 #include <ruby.h>
 #include <ruby/encoding.h>
+#include <ruby/thread.h>
 #include <sybfront.h>
 #include <sybdb.h>
 


### PR DESCRIPTION
This is an alternate implementation of #217, with some slightly more
minimal changes. I didn't feel the need to move out the error code into
a separate file, and just forward declared the functions in the location
they were already at.

I'm a little concerned at the change from `char **` to `char *`, as that
code should have done horribly incorrect things if those pointers were
ever used previously. Everything else is pretty straightforward, just
missing some forward declarations and using the correct pointer casts
(pointer casting doesn't actually affect anything other than making the
compiler hush).