### PR TITLE
Update FreeTDS to 0.95.20 and use bz2 download

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The API is simple and consists of these classes:
 
 ## Install
 
-Installing with rubygems should just work. TinyTDS is currently tested on Ruby version 1.9.3 and upward.
+Installing with rubygems should just work. TinyTDS is currently tested on Ruby version 2.0.0 and upward.
 
 ```
 $ gem install tiny_tds
@@ -323,7 +323,7 @@ To find out more about the FreeTDS release system [visit this thread](http://lis
 
 ## Compiling Gems for Windows
 
-For the convenience of Windows users, TinyTDS ships pre-compiled gems for Ruby 1.9.3, 2.0, 2.1 and 2.2 on Windows. In order to generate these gems, [rake-compiler-dock](https://github.com/rake-compiler/rake-compiler-dock) is used. This project provides a [Docker image](https://registry.hub.docker.com/u/larskanis/rake-compiler-dock/) with rvm, cross-compilers and a number of different target versions of Ruby.
+For the convenience of Windows users, TinyTDS ships pre-compiled gems for Ruby 2.0, 2.1 and 2.2 on Windows. In order to generate these gems, [rake-compiler-dock](https://github.com/rake-compiler/rake-compiler-dock) is used. This project provides a [Docker image](https://registry.hub.docker.com/u/larskanis/rake-compiler-dock/) with rvm, cross-compilers and a number of different target versions of Ruby.
 
 Run the following rake task to compile the gems for Windows. This will check the availability of [Docker](https://www.docker.com/) (and boot2docker on Windows or OS-X) and will give some advice for download and installation. When docker is running, it will download the docker image (once-only) and start the build:
 

--- a/Rakefile
+++ b/Rakefile
@@ -91,7 +91,7 @@ end
 
 # Bundle the freetds sources to avoid download while gem install
 task gem_build_path(gemspec) do
-  add_file_to_gem(gemspec, "ports/archives/freetds-0.91.112.tar.gz")
+  add_file_to_gem(gemspec, "ports/archives/freetds-0.95.64.tar.bz2")
 end
 
 desc "Build the windows binary gems per rake-compiler-dock"

--- a/Rakefile
+++ b/Rakefile
@@ -99,6 +99,6 @@ task 'gem:windows' do
   require 'rake_compiler_dock'
   RakeCompilerDock.sh <<-EOT
 #    bundle install &&
-    rake cross native gem RUBY_CC_VERSION=1.9.3:2.0.0:2.1.6:2.2.2
+    rake cross native gem RUBY_CC_VERSION=2.0.0:2.1.6:2.2.2
   EOT
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,3 +40,5 @@ environment:
     - ruby_version: "21-x64"
     - ruby_version: "22"
     - ruby_version: "22-x64"
+on_failure:
+  - find -name compile.log | xargs cat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,6 @@ test_script:
   - bundle exec rake TINYTDS_UNIT_HOST_TEST=localhost TINYTDS_UNIT_DATASERVER="localhost\SQL2008R2SP2" TINYTDS_SCHEMA=sqlserver_2008
 environment:
   matrix:
-    - ruby_version: "193"
     - ruby_version: "200"
     - ruby_version: "200-x64"
     - ruby_version: "21"

--- a/ext/tiny_tds/extconf.rb
+++ b/ext/tiny_tds/extconf.rb
@@ -110,7 +110,13 @@ class BuildRecipe < MiniPortile
   end
 
   def port_path
+    # Use the same path for all recipes, so that only one include/lib path is required.
     "#{target}/#{host}"
+  end
+
+  def installed?
+    # We use the same port_path for all recipes. That breaks the standard installed? method.
+    false
   end
 
   # When using rake-compiler-dock on Windows, the underlying Virtualbox shared

--- a/ext/tiny_tds/extconf.rb
+++ b/ext/tiny_tds/extconf.rb
@@ -14,13 +14,11 @@ ICONV_SOURCE_URI = "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{ICONV_VERSION
 OPENSSL_VERSION = ENV['TINYTDS_OPENSSL_VERSION'] || '1.0.2d'
 OPENSSL_SOURCE_URI = "http://www.openssl.org/source/openssl-#{OPENSSL_VERSION}.tar.gz"
 
-FREETDS_VERSION = ENV['TINYTDS_FREETDS_VERSION'] || "0.91"
+FREETDS_VERSION = ENV['TINYTDS_FREETDS_VERSION'] || "0.95.64"
 FREETDS_VERSION_INFO = Hash.new { |h,k|
-  h[k] = {:files => "ftp://ftp.freetds.org/pub/freetds/stable/freetds-#{k}.tar.gz"}
+  h[k] = {:files => "ftp://ftp.freetds.org/pub/freetds/stable/freetds-#{k}.tar.bz2"}
 }.merge({
   "0.82" => {:files => "ftp://ftp.freetds.org/pub/freetds/old/0.82/freetds-0.82.tar.gz"},
-  "0.91" => {:files => "ftp://ftp.freetds.org/pub/freetds/stable/freetds-0.91.112.tar.gz"},
-  "0.92" => {:files => "ftp://ftp.freetds.org/pub/freetds/stable/freetds-0.92.405.tar.gz"},
   "current" => {:files => "ftp://ftp.freetds.org/pub/freetds/current/freetds-current.tar.gz"}
 })
 FREETDS_SOURCE_URI = FREETDS_VERSION_INFO[FREETDS_VERSION][:files]

--- a/ext/tiny_tds/extconf.rb
+++ b/ext/tiny_tds/extconf.rb
@@ -95,10 +95,8 @@ class BuildRecipe < MiniPortile
   end
 
   def consolidated_host(name)
-    # For ruby-1.9.3 we use newer mingw-w64 (i686-w64-mingw32) to build the shared libraries
-    # and mingw32 (i586-mingw32msvc) to build the extension.
-    name.gsub('i586-mingw32msvc', 'i686-w64-mingw32').
-         gsub('i686-pc-mingw32', 'i686-w64-mingw32')
+    # Host name and prefix of build tools are different on Windows 32 bit.
+    name.gsub('i686-pc-mingw32', 'i686-w64-mingw32')
   end
 
   def configure_defaults

--- a/lib/tiny_tds.rb
+++ b/lib/tiny_tds.rb
@@ -15,8 +15,7 @@ if RUBY_PLATFORM =~ /mingw|mswin/ && RUBY_VERSION =~ /(\d+.\d+)/
   old_path = ENV['PATH']
   begin
     # Do the same host consolidation as in extconf.rb
-    ports_dir = RbConfig::CONFIG["host"].gsub('i586-mingw32msvc', 'i686-w64-mingw32').
-                                         gsub('i686-pc-mingw32', 'i686-w64-mingw32')
+    ports_dir = RbConfig::CONFIG["host"].gsub('i686-pc-mingw32', 'i686-w64-mingw32')
     ENV['PATH'] = "#{File.expand_path("../../ports/#{ports_dir}/bin", __FILE__)};#{old_path}"
     require "tiny_tds/#{ver}/tiny_tds"
   rescue LoadError

--- a/ports/patches/freetds/0.95.64/0001-mingw_missing_inet_pton.diff
+++ b/ports/patches/freetds/0.95.64/0001-mingw_missing_inet_pton.diff
@@ -1,0 +1,34 @@
+diff --git a/src/tds/tls.c b/src/tds/tls.c
+index 0d11a33..b8ab2ba 100644
+--- a/src/tds/tls.c
++++ b/src/tds/tls.c
+@@ -72,6 +72,29 @@
+ #define SSL_PTR bio->ptr
+ #endif
+
++/*
++ * Add a workaround for older Mingw versions without inet_pton().
++ * This means RubyInstallers DevKit-4.7.2 in particular.
++ */
++#if defined(__MINGW64_VERSION_MAJOR) && !defined(InetPtonA)
++  #include <windows.h>
++
++  static HMODULE ws2_32 = NULL;
++  typedef INT (WINAPI * __inet_pton)(INT Family, LPCWSTR pStringBuf, PVOID pAddr);
++  static __inet_pton _inet_pton = NULL;
++
++  INT WINAPI inet_pton(INT Family, LPCWSTR pStringBuf, PVOID pAddr)
++  {
++    if (_inet_pton == NULL) {
++      ws2_32 = LoadLibraryEx("Ws2_32.dll", NULL, 0);
++
++      _inet_pton = (__inet_pton)GetProcAddress(ws2_32, "inet_pton");
++    }
++
++    return (_inet_pton)(Family, pStringBuf, pAddr);
++  }
++#endif
++
+ static SSL_RET
+ tds_pull_func_login(SSL_PULL_ARGS)
+ {

--- a/ports/patches/freetds/0.95.64/0002-avoid-problem-with-getpid-definition.diff
+++ b/ports/patches/freetds/0.95.64/0002-avoid-problem-with-getpid-definition.diff
@@ -1,0 +1,26 @@
+diff --git a/src/replacements/fakepoll.c b/src/replacements/fakepoll.c
+index a043438..b722c8a 100644
+--- a/src/replacements/fakepoll.c
++++ b/src/replacements/fakepoll.c
+@@ -24,6 +24,10 @@
+ #include <stdarg.h>
+ #include <stdio.h>
+
++#if HAVE_UNISTD_H
++#include <unistd.h>
++#endif /* HAVE_UNISTD_H */
++
+ #include "replacements.h"
+
+ #if HAVE_SYS_TYPES_H
+@@ -34,10 +38,6 @@
+ #include <errno.h>
+ #endif /* HAVE_ERRNO_H */
+
+-#if HAVE_UNISTD_H
+-#include <unistd.h>
+-#endif /* HAVE_UNISTD_H */
+-
+ #include <freetds/time.h>
+
+ #include <string.h>

--- a/tiny_tds.gemspec
+++ b/tiny_tds.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.rdoc_options  = ['--charset=UTF-8']
   s.extensions    = ['ext/tiny_tds/extconf.rb']
   s.license       = 'MIT'
+  s.required_ruby_version = '>= 2.0.0'
   s.add_runtime_dependency     'mini_portile', '0.6.2'
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'rake-compiler', '0.9.5'


### PR DESCRIPTION
Not sure, whether there is a reason to use 0.91.112 ?

Unfortunately there is an issue with 0.95.20: It makes use of `inet_pton()`, but this is not yet supported in the old RubyInstaller's DevKit version 4.7.2. In order to work around this issue, I added a patch to freetds, that implements it as a wrapper to the `ws2_32.dll`.

I currently have no Windows box to hand to test this - so this is WIP! I'll try it out in the next days.
