### PR TITLE
Make sure to close all test connections.

### DIFF
--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -48,6 +48,7 @@ class ClientTest < TinyTds::TestCase
         client = new_connection(:encoding => encoding)
         assert_equal encoding, client.charset
         assert_equal Encoding.find(encoding), client.encoding
+        client.close
       end
     end
 
@@ -55,6 +56,7 @@ class ClientTest < TinyTds::TestCase
       host = ENV['TINYTDS_UNIT_HOST_TEST'] || ENV['TINYTDS_UNIT_HOST']
       port = ENV['TINYTDS_UNIT_PORT_TEST'] || ENV['TINYTDS_UNIT_PORT'] || 1433
       client = new_connection dataserver: nil, host: host, port: port
+      client.close
     end unless sqlserver_azure?
 
   end
@@ -89,6 +91,7 @@ class ClientTest < TinyTds::TestCase
         assert_match %r{timed out}i, e.message, 'ignore if non-english test run'
       end
       assert_client_works(client)
+      close_client(client)
       assert_new_connections_work
     end
 
@@ -97,6 +100,7 @@ class ClientTest < TinyTds::TestCase
       client.execute("WaitFor Delay '00:00:01'").do
       client.execute("WaitFor Delay '00:00:01'").do
       client.execute("WaitFor Delay '00:00:01'").do
+      close_client(client)
     end
 
     it 'must not timeout per sql batch when under transaction' do
@@ -108,6 +112,7 @@ class ClientTest < TinyTds::TestCase
         client.execute("WaitFor Delay '00:00:01'").do
       ensure
         client.execute("COMMIT TRANSACTION").do
+        close_client(client)
       end
     end
 
@@ -134,6 +139,7 @@ class ClientTest < TinyTds::TestCase
           assert_equal 1, e.severity
           assert_match %r{dead or not enabled}i, e.message, 'ignore if non-english test run'
         end
+        close_client(client)
         assert_new_connections_work
       end
     end

--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -397,6 +397,7 @@ class ResultTest < TinyTds::TestCase
       describe 'using :empty_sets TRUE' do
 
         before do
+          close_client
           @old_query_option_value = TinyTds::Client.default_query_options[:empty_sets]
           TinyTds::Client.default_query_options[:empty_sets] = true
           @client = new_connection
@@ -477,6 +478,7 @@ class ResultTest < TinyTds::TestCase
       describe 'using :empty_sets FALSE' do
 
         before do
+          close_client
           @old_query_option_value = TinyTds::Client.default_query_options[:empty_sets]
           TinyTds::Client.default_query_options[:empty_sets] = false
           @client = new_connection
@@ -668,12 +670,14 @@ class ResultTest < TinyTds::TestCase
       end
 
       it 'must not error at all from reading non-convertable charcters and just use ? marks' do
+        close_client
         @client = new_connection :encoding => 'ASCII'
         @client.charset.must_equal 'ASCII'
         find_value(202, :nvarchar_50).must_equal 'test nvarchar_50 ??'
       end
 
       it 'must error gracefully from writing non-convertable characters' do
+        close_client
         @client = new_connection :encoding => 'ASCII'
         @client.charset.must_equal 'ASCII'
         rollback_transaction(@client) do

--- a/test/thread_test.rb
+++ b/test/thread_test.rb
@@ -15,6 +15,10 @@ class ThreadTest < TinyTds::TestCase
       @pool = ConnectionPool.new(:size => @poolsize, :timeout => 5) { new_connection }
     end
 
+    after do
+      @pool.shutdown { |c| c.close }
+    end
+
     it 'should finish faster in parallel' do
       skip if sqlserver_azure?
       x = Benchmark.realtime do


### PR DESCRIPTION
When upgrading to newer FreeTDS versions, we should really make sure we are not crossing the streams when testing and close every client connection we create.