### PR TITLE
Local ruby binstubs `./bin/tsql` for `./exe/tsql` executable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ lib/tiny_tds/tiny_tds.rb
 Gemfile.lock
 misc
 *.gem
+/exe/tsql
 /ports/*
 !/ports/patches/

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 * 0.9.5 *
 
-* Add support for 2008 data types. Must use TDSVER 7.3 or higher. Fixes #227 #251
+* Binstub wrappers for `tsql`. Fixes #227 #251
+* Add support for 2008 data types. Must use TDSVER 7.3 or higher. Fixes #244 #251
   - [date]
   - [datetime2]
   - [datetimeoffset]

--- a/README.md
+++ b/README.md
@@ -280,6 +280,13 @@ By default row caching is turned on because the SQL Server adapter for ActiveRec
 TinyTDS takes an opinionated stance on how we handle encoding errors. First, we treat errors differently on reads vs. writes. Our opinion is that if you are reading bad data due to your client's encoding option, you would rather just find `?` marks in your strings vs being blocked with exceptions. This is how things wold work via ODBC or SMS. On the other hand, writes will raise an exception. In this case we raise the SYBEICONVO/2402 error message which has a description of `Error converting characters into server's character set. Some character(s) could not be converted.`. Even though the severity of this message is only a `4` and TinyTDS will automatically strip/ignore unknown characters, we feel you should know that you are inserting bad encodings. In this way, a transaction can be rolled back, etc. Remember, any database write that has bad characters due to the client encoding will still be written to the database, but it is up to you rollback said write if needed. Most ORMs like ActiveRecord handle this scenario just fine.
 
 
+## Binstubs
+
+The TinyTDS gem uses binstub wrappers which mirror compiled [FreeTDS Utilities](http://www.freetds.org/userguide/usefreetds.htm) binaries. These native executables are usually installed at the system level when installing FreeTDS. However, when using MiniPortile to install TinyTDS as we do with Windows binaries, these binstubs will find and prefer local gem `exe` directory executables. These are the following binstubs we wrap.
+
+* tsql - Used to test connections and debug compile time settings.
+
+
 ## Using TinyTDS With Rails & The ActiveRecord SQL Server adapter.
 
 TinyTDS is the default connection mode for the SQL Server adapter in versions 3.1 or higher. The SQL Server adapter can be found using the links below.

--- a/bin/tsql
+++ b/bin/tsql
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+gem 'ptools' ; require 'ptools'
+
+path = File.symlink?(__FILE__) ? File.readlink(__FILE__) : __FILE__
+tsql = File.expand_path(File.join File.dirname(path), '..', 'exe', 'tsql')
+tsql = File.which('tsql') unless File.exists?(tsql)
+
+Kernel.system tsql, *ARGV

--- a/bin/tsql
+++ b/bin/tsql
@@ -1,9 +1,25 @@
 #!/usr/bin/env ruby
 
-gem 'ptools' ; require 'ptools'
+BIN   = 'tsql'
+ROOT  = File.expand_path(File.join File.dirname(File.symlink?(__FILE__) ? File.readlink(__FILE__) : __FILE__), '..')
+PATHS = ENV['PATH'].split(File::PATH_SEPARATOR)
+EXTS  = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+SELF  = File.join ROOT, 'bin', BIN
+EXE   = File.join ROOT, 'exe', BIN
 
-path = File.symlink?(__FILE__) ? File.readlink(__FILE__) : __FILE__
-tsql = File.expand_path(File.join File.dirname(path), '..', 'exe', 'tsql')
-tsql = File.which('tsql') unless File.exists?(tsql)
+def which(cmd)
+  PATHS.each do |path|
+    EXTS.each do |ext|
+      exe = File.expand_path File.join(path, "#{cmd}#{ext}"), ROOT
+      next unless File.executable?(exe)
+      next if exe == SELF
+      return exe
+    end
+  end
+  return nil
+end
 
-Kernel.system tsql, *ARGV
+bin = File.exists?(EXE) ? EXE : which(BIN)
+puts "[TinyTds] #{BIN}: #{bin}"
+
+Kernel.system bin, *ARGV

--- a/ext/tiny_tds/extconf.rb
+++ b/ext/tiny_tds/extconf.rb
@@ -5,7 +5,6 @@ ENV['RC_ARCHS'] = '' if RUBY_PLATFORM =~ /darwin/
 require 'mkmf'
 require 'mini_portile'
 require 'fileutils'
-require 'ptools'
 require_relative './extconsts'
 
 # Shamelessly copied from nokogiri
@@ -224,9 +223,9 @@ def define_freetds_recipe(host, libiconv, libssl, gnutls)
           bin_path = File.expand_path File.join(path, 'bin')
           exe_path = File.expand_path File.join(target, '..', 'exe')
           return unless File.directory?(bin_path)
-          $: << bin_path
+          ENV['PATH'] = "#{bin_path}#{File::PATH_SEPARATOR}#{ENV['PATH']}" unless ENV['PATH'].include?(bin_path)
           ['tsql'].each do |bin|
-            path = File.which(bin)
+            path = which(bin)
             next unless path.include?(bin_path)
             FileUtils.cp path, exe_path
           end

--- a/tiny_tds.gemspec
+++ b/tiny_tds.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
   s.required_ruby_version = '>= 2.0.0'
   s.add_runtime_dependency     'mini_portile', '0.6.2'
-  s.add_runtime_dependency     'ptools'
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'rake-compiler', '0.9.5'
   s.add_development_dependency 'rake-compiler-dock', '~> 0.4.3'

--- a/tiny_tds.gemspec
+++ b/tiny_tds.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
   s.required_ruby_version = '>= 2.0.0'
   s.add_runtime_dependency     'mini_portile', '0.6.2'
+  s.add_runtime_dependency     'ptools'
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'rake-compiler', '0.9.5'
   s.add_development_dependency 'rake-compiler-dock', '~> 0.4.3'


### PR DESCRIPTION
See #227 for full details.

* Copy `tsql` exe during FreeTDS compile install.
* Use ptools gem dep for easy cross platform `File.which` support.
* Local binstub will prefer local gem exe but delegate to system as needed.