### PR TITLE
Update to mini_portile2 and fix packaging of freetds tar as bz2.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -86,14 +86,14 @@ end
 
 # Bundle the freetds sources to avoid download while gem install.
 task gem_build_path(gemspec) do
-  add_file_to_gem gemspec, "ports/archives/freetds-#{FREETDS_VERSION}.tar.gz"
+  add_file_to_gem gemspec, "ports/archives/freetds-#{FREETDS_VERSION}.tar.bz2"
 end
 
 desc "Build the windows binary gems per rake-compiler-dock"
 task 'gem:windows' do
   require 'rake_compiler_dock'
   RakeCompilerDock.sh <<-EOT
-    rake cross native gem RUBY_CC_VERSION=2.0.0:2.1.6:2.2.2 CFLAGS="-Wall"
+    bundle && rake cross native gem RUBY_CC_VERSION=2.0.0:2.1.6:2.2.2 CFLAGS="-Wall"
   EOT
 end
 

--- a/ext/tiny_tds/extconf.rb
+++ b/ext/tiny_tds/extconf.rb
@@ -3,8 +3,12 @@ ENV['RC_ARCHS'] = '' if RUBY_PLATFORM =~ /darwin/
 # :stopdoc:
 
 require 'mkmf'
-require 'mini_portile'
 require 'fileutils'
+
+# The gem version constraint in the gemspec is not respected at install time.
+# Keep this version in sync with the one in the gemspec !
+gem 'mini_portile2', '~> 2.0'
+require 'mini_portile2'
 require_relative './extconsts'
 
 # Shamelessly copied from nokogiri
@@ -210,8 +214,8 @@ def define_freetds_recipe(host, libiconv, libssl, gnutls)
     if libiconv
       # For some reason freetds doesn't honor --with-libiconv-prefix
       # so we have do add it by hand:
-      recipe.configure_options << "\"CFLAGS=-I#{libiconv.path}/include\""
-      recipe.configure_options << "\"LDFLAGS=-L#{libiconv.path}/lib -liconv\""
+      recipe.configure_options << "CFLAGS=-I#{libiconv.path}/include"
+      recipe.configure_options << "LDFLAGS=-L#{libiconv.path}/lib -liconv"
     end
 
     class << recipe

--- a/tiny_tds.gemspec
+++ b/tiny_tds.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.extensions    = ['ext/tiny_tds/extconf.rb']
   s.license       = 'MIT'
   s.required_ruby_version = '>= 2.0.0'
-  s.add_runtime_dependency     'mini_portile', '0.6.2'
+  s.add_runtime_dependency     'mini_portile2', '~> 2.0' # Keep this version in sync with the one in extconf.rb !
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'rake-compiler', '0.9.5'
   s.add_development_dependency 'rake-compiler-dock', '~> 0.4.3'


### PR DESCRIPTION
This should fix https://github.com/rails-sqlserver/tiny_tds/issues/252 . 

I was able to reproduce the "undefined method `include?' for nil:NilClass" error in #252 . But after the update to mini_portile2 it magically disappeared and `rake gem:windows` works fine now.

As a side note: rake-compiler-dock-0.5.0 will support ruby-2.3 as well. I'll release it when ruby-2.3.0 is released, so that binary gems can be built.