### PR TITLE
Add patch for getopt

### DIFF
--- a/ports/patches/freetds/0.95.78/0002-missing-getopt-include.diff
+++ b/ports/patches/freetds/0.95.78/0002-missing-getopt-include.diff
@@ -1,0 +1,12 @@
+diff --git a/src/apps/tsql.c b/src/apps/tsql.c
+index 9015262..3ff9475 100644
+--- a/src/apps/tsql.c
++++ b/src/apps/tsql.c
+@@ -22,6 +22,7 @@
+ 
+ #include <freetds/time.h>
+ 
++#include <getopt.h>
+ #include <stdio.h>
+ #include <assert.h>
+ #include <ctype.h>


### PR DESCRIPTION
I was trying to get the latest to install on alpine linux, stole this from http://git.alpinelinux.org/cgit/aports/tree/main/freetds/fix-includes.patch