### PR TITLE
Add ruby 2.3 to the cross compile task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -94,7 +94,7 @@ desc "Build the windows binary gems per rake-compiler-dock"
 task 'gem:windows' do
   require 'rake_compiler_dock'
   RakeCompilerDock.sh <<-EOT
-    bundle && rake cross native gem RUBY_CC_VERSION=2.0.0:2.1.6:2.2.2 CFLAGS="-Wall"
+    bundle && rake cross native gem RUBY_CC_VERSION=2.0.0:2.1.6:2.2.2:2.3.0 CFLAGS="-Wall"
   EOT
 end
 

--- a/tiny_tds.gemspec
+++ b/tiny_tds.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency     'mini_portile2', '~> 2.0' # Keep this version in sync with the one in extconf.rb !
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'rake-compiler', '0.9.5'
-  s.add_development_dependency 'rake-compiler-dock', '~> 0.4.3'
+  s.add_development_dependency 'rake-compiler-dock', '~> 0.5.1'
   s.add_development_dependency 'minitest', '~> 5.6'
   s.add_development_dependency 'connection_pool', '~> 2.2'
 end


### PR DESCRIPTION
I haven't actually tested it, so this PR is really to start the discussion. Are there blockers to cross compiling for 2.3?