### PR TITLE
Always set database name in login packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Creating a new client takes a hash of options. For valid iconv encoding options,
 * :timeout - Seconds to wait for a response to a SQL command. Default 5 seconds.
 * :encoding - Any valid iconv value like CP1251 or ISO-8859-1. Default UTF-8.
 * :azure - Pass true to signal that you are connecting to azure.
+* :contained - Pass true to signal that you are connecting with a contained database user.
 
 Use the `#active?` method to determine if a connection is good. The implementation of this method may change but it should always guarantee that a connection is good. Current it checks for either a closed or dead connection.
 


### PR DESCRIPTION
Allows support for contained users in recent SQL Server versions.

Running the specs from OS X against SQL Server 2016 (on remote windows server obviously)
renders one test failure, however the same failure is also present on `master`:
```
Basic query and result#test_0015_must insert and find unicode data [/Users/lowe/src/tiny_tds/test/result_test.rb:131]:
```

It's probably important to run on appveyor etc to make sure we don't break compatibility with old SQL Server versions.