### PR TITLE
Error messages greater than 1024 chars generates a buffer overflow

### DIFF
--- a/ext/tiny_tds/client.c
+++ b/ext/tiny_tds/client.c
@@ -110,8 +110,8 @@ int tinytds_err_handler(DBPROCESS *dbproc, int severity, int dberr, int oserr, c
     */
     if (!userdata->nonblocking_error.is_set) {
       userdata->nonblocking_error.cancel = cancel;
-      strcpy(userdata->nonblocking_error.error, dberrstr);
-      strcpy(userdata->nonblocking_error.source, source);
+      strncpy(userdata->nonblocking_error.error, dberrstr, ERROR_MSG_SIZE);
+      strncpy(userdata->nonblocking_error.source, source, ERROR_MSG_SIZE);
       userdata->nonblocking_error.severity = severity;
       userdata->nonblocking_error.dberr = dberr;
       userdata->nonblocking_error.oserr = oserr;
@@ -133,8 +133,8 @@ int tinytds_msg_handler(DBPROCESS *dbproc, DBINT msgno, int msgstate, int severi
     if (userdata && userdata->nonblocking) {
       if (!userdata->nonblocking_error.is_set) {
         userdata->nonblocking_error.cancel = 1;
-        strcpy(userdata->nonblocking_error.error, msgtext);
-        strcpy(userdata->nonblocking_error.source, source);
+        strncpy(userdata->nonblocking_error.error, msgtext, ERROR_MSG_SIZE);
+        strncpy(userdata->nonblocking_error.source, source, ERROR_MSG_SIZE);
         userdata->nonblocking_error.severity = severity;
         userdata->nonblocking_error.dberr = msgno;
         userdata->nonblocking_error.oserr = msgstate;

--- a/ext/tiny_tds/client.h
+++ b/ext/tiny_tds/client.h
@@ -4,11 +4,13 @@
 
 void init_tinytds_client();
 
+#define ERROR_MSG_SIZE 1024
+
 typedef struct {
   short int is_set;
   int cancel;
-  char error[1024];
-  char source[1024];
+  char error[ERROR_MSG_SIZE];
+  char source[ERROR_MSG_SIZE];
   int severity;
   int dberr;
   int oserr;


### PR DESCRIPTION
We have some stored procedures implemented in C#, deployed as a DLL on SQL Server.

In some scenarios, an exception is thrown and the error message + the stack trace of the error generates a message greater than 2048 characters.

As the fields `error` and `source`, of the `tinytds_errordata` struct, are defined with size 1024, it generates a buffer overflow error for messages greater than this value, which ends up killing the process.

In this PR, the suggestion is to use `strncpy` instead of `strcpy`, to shrink the message if it is greater than a defined size.

[logs.zip](https://github.com/rails-sqlserver/tiny_tds/files/370295/logs.zip)


