### PR TITLE
Don't reset use_utf16 option, when initializing with false

### DIFF
--- a/ext/tiny_tds/client.c
+++ b/ext/tiny_tds/client.c
@@ -409,6 +409,7 @@ void init_tinytds_client() {
   sym_encoding = ID2SYM(rb_intern("encoding"));
   sym_azure = ID2SYM(rb_intern("azure"));
   sym_contained = ID2SYM(rb_intern("contained"));
+  sym_use_utf16 = ID2SYM(rb_intern("use_utf16"));
   /* Intern TinyTds::Error Accessors */
   intern_source_eql = rb_intern("source=");
   intern_severity_eql = rb_intern("severity=");

--- a/lib/tiny_tds/client.rb
+++ b/lib/tiny_tds/client.rb
@@ -42,7 +42,7 @@ module TinyTds
       opts[:password] = opts[:password].to_s if opts[:password] && opts[:password].to_s.strip != ''
       opts[:appname] ||= 'TinyTds'
       opts[:tds_version] = tds_versions_setter(opts)
-      opts[:use_utf16] = ["true", "1", "yes"].include?(opts[:use_utf16].to_s)
+      opts[:use_utf16] = opts[:use_utf16].nil? || ["true", "1", "yes"].include?(opts[:use_utf16].to_s)
       opts[:login_timeout] ||= 60
       opts[:timeout] ||= 5
       opts[:encoding] = opts[:encoding].nil? || opts[:encoding].casecmp('utf8').zero? ? 'UTF-8' : opts[:encoding].upcase

--- a/lib/tiny_tds/client.rb
+++ b/lib/tiny_tds/client.rb
@@ -42,7 +42,7 @@ module TinyTds
       opts[:password] = opts[:password].to_s if opts[:password] && opts[:password].to_s.strip != ''
       opts[:appname] ||= 'TinyTds'
       opts[:tds_version] = tds_versions_setter(opts)
-      opts[:use_utf16] ||= true
+      opts[:use_utf16] = ["true", "1", "yes"].include?(opts[:use_utf16].to_s)
       opts[:login_timeout] ||= 60
       opts[:timeout] ||= 5
       opts[:encoding] = opts[:encoding].nil? || opts[:encoding].casecmp('utf8').zero? ? 'UTF-8' : opts[:encoding].upcase


### PR DESCRIPTION
||= is a deceiving operator for Boolean values. It could mean, assign-if-nil or assign-if-false. It is just a short-hand for `a = a || new_value`
