### PR TITLE
More CircleCI with Less Appveyor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* master *
+
+* Appveyor tests only 2012, 2014 with one Ruby, 23-x64.
+* CircleCI tests 2016.
+
+
 * 1.0.5 *
 
 * Windows Static Builds - Use FreeTDS 1.00.15, OpenSSL 1.0.2j.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,12 +22,6 @@ test_script:
   - timeout /t 4 /nobreak > NUL
   - powershell -File "%APPVEYOR_BUILD_FOLDER%\test\appveyor\dbsetup.ps1"
   - timeout /t 4 /nobreak > NUL
-  - ps: Start-Service 'MSSQL$SQL2016'
-  - timeout /t 4 /nobreak > NUL
-  - sqlcmd -S ".\SQL2016" -U sa -P Password12! -i %APPVEYOR_BUILD_FOLDER%\test\appveyor\dbsetup.sql
-  - bundle exec rake TINYTDS_UNIT_HOST_TEST=localhost TINYTDS_UNIT_DATASERVER="localhost\SQL2016" TINYTDS_SCHEMA=sqlserver_2014 TDSVER=7.1
-  - bundle exec rake TINYTDS_UNIT_HOST_TEST=localhost TINYTDS_UNIT_DATASERVER="localhost\SQL2016" TINYTDS_SCHEMA=sqlserver_2014
-  - ps: Stop-Service 'MSSQL$SQL2016'
   - ps: Start-Service 'MSSQL$SQL2014'
   - timeout /t 4 /nobreak > NUL
   - sqlcmd -S ".\SQL2014" -U sa -P Password12! -i %APPVEYOR_BUILD_FOLDER%\test\appveyor\dbsetup.sql
@@ -45,7 +39,5 @@ environment:
     secure: fYKSKV4v+36OFQp2nZdX4DfUpgmy5cm0wuR73cgdmEk=
   matrix:
     - ruby_version: "23-x64"
-    - ruby_version: "23"
-    - ruby_version: "200"
 on_failure:
   - find -name compile.log | xargs cat

--- a/circle.yml
+++ b/circle.yml
@@ -17,3 +17,6 @@ database:
   post:
     - ./test/bin/setup.sh
 
+test:
+  override:
+    - bundle exec rake

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,7 @@ general:
 machine:
   environment:
     TESTOPTS: -v
+    TINYTDS_UNIT_HOST_TEST: localhost
   services:
     - docker
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,19 @@
+general:
+  branches:
+    ignore:
+      - /dev.*/
+
+machine:
+  environment:
+    TESTOPTS: -v
+  services:
+    - docker
+
+dependencies:
+  post:
+    - docker info
+
+database:
+  post:
+    - ./test/bin/setup.sh
+

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ general:
 machine:
   environment:
     TESTOPTS: -v
-    TINYTDS_UNIT_HOST_TEST: localhost
+    TINYTDS_UNIT_HOST: localhost
   services:
     - docker
 

--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,10 @@ machine:
     - docker
 
 dependencies:
+  override:
+    - rvm-exec 2.1.9 bundle install
+    - rvm-exec 2.2.5 bundle install
+    - rvm-exec 2.3.1 bundle install
   post:
     - docker info
 
@@ -20,4 +24,6 @@ database:
 
 test:
   override:
-    - bundle exec rake
+    - rvm-exec 2.1.9 bundle exec rake
+    - rvm-exec 2.2.5 bundle exec rake
+    - rvm-exec 2.3.1 bundle exec rake

--- a/test/bin/install-freetds-1.00.21.sh
+++ b/test/bin/install-freetds-1.00.21.sh
@@ -1,17 +1,5 @@
 #!/usr/bin/env bash
 
-
-# docker exec $container locale-gen "en_US.UTF-8"
-# docker exec $container /bin/sh -c "echo 'export LANG=en_US.UTF-8' >> /root/.bashrc"
-# docker exec $container apt-get update
-# docker exec $container apt-get install build-essential -y
-# docker exec $container apt-get install wget -y
-
-# docker cp test/bin/install-freetds-1.00.21.sh $container:~/root
-# docker exec $container /root/install-freetds-1.00.21.sh
-
-
-cd ~
 wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.00.21.tar.gz
 tar -xzf freetds-1.00.21.tar.gz
 cd freetds-1.00.21

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -85,14 +85,14 @@ class ClientTest < TinyTds::TestCase
       action = lambda { new_connection(options) }
       assert_raise_tinytds_error(action) do |e|
         # Not sure why tese are different.
-        if ruby_windows?
-          assert_equal 20012, e.db_error_number
-          assert_equal 2, e.severity
-          assert_match %r{server name not found in configuration files}i, e.message, 'ignore if non-english test run'
-        else
+        if ruby_darwin?
           assert_equal 20009, e.db_error_number
           assert_equal 9, e.severity
           assert_match %r{is unavailable or does not exist}i, e.message, 'ignore if non-english test run'
+        else
+          assert_equal 20012, e.db_error_number
+          assert_equal 2, e.severity
+          assert_match %r{server name not found in configuration files}i, e.message, 'ignore if non-english test run'
         end
       end
       assert_new_connections_work

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -84,9 +84,16 @@ class ClientTest < TinyTds::TestCase
       options = connection_options :login_timeout => 1, :dataserver => 'DOESNOTEXIST'
       action = lambda { new_connection(options) }
       assert_raise_tinytds_error(action) do |e|
-        assert_equal 20009, e.db_error_number
-        assert_equal 9, e.severity
-        assert_match %r{is unavailable or does not exist}i, e.message, 'ignore if non-english test run'
+        # Not sure why tese are different.
+        if ruby_windows?
+          assert_equal 20012, e.db_error_number
+          assert_equal 2, e.severity
+          assert_match %r{server name not found in configuration files}i, e.message, 'ignore if non-english test run'
+        else
+          assert_equal 20009, e.db_error_number
+          assert_equal 9, e.severity
+          assert_match %r{is unavailable or does not exist}i, e.message, 'ignore if non-english test run'
+        end
       end
       assert_new_connections_work
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -142,6 +142,10 @@ module TinyTds
       RbConfig::CONFIG['host_os'] =~ /ming/
     end
 
+    def ruby_darwin?
+      RbConfig::CONFIG['host_os'] =~ /darwin/
+    end
+
     def load_current_schema
       loader = new_connection
       schema_file = File.expand_path File.join(File.dirname(__FILE__), 'schema', "#{current_schema}.sql")


### PR DESCRIPTION
The goal here is to use Appveyor only for the following:

* Non-current SQL Server. Examples 2014 and 2012.
* Lastest Ruby 64-bit version.

All other things will be left to CircleCI. Primarily this includes:

* Testing all major-supported Ruby versions.
* Testing SQL Server Linux & Ubuntu.