### PR TITLE
Use alternate freetds source for 1.00.26

### DIFF
--- a/ext/tiny_tds/extconsts.rb
+++ b/ext/tiny_tds/extconsts.rb
@@ -5,10 +5,11 @@ ICONV_SOURCE_URI = "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{ICONV_VERSION
 OPENSSL_VERSION = ENV['TINYTDS_OPENSSL_VERSION'] || '1.0.2j'
 OPENSSL_SOURCE_URI = "https://www.openssl.org/source/openssl-#{OPENSSL_VERSION}.tar.gz"
 
-FREETDS_VERSION = ENV['TINYTDS_FREETDS_VERSION'] || "1.00.21"
+FREETDS_VERSION = ENV['TINYTDS_FREETDS_VERSION'] || "1.00.26"
 FREETDS_VERSION_INFO = Hash.new { |h,k|
   h[k] = {files: "ftp://ftp.freetds.org/pub/freetds/stable/freetds-#{k}.tar.bz2"}
 }
+FREETDS_VERSION_INFO['1.00.26'] = {files: 'https://fossies.org/linux/privat/freetds-1.00.26.tar.gz'}
 FREETDS_VERSION_INFO['1.00'] = {files: 'ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.00.tar.bz2'}
 FREETDS_VERSION_INFO['0.99'] = {files: 'ftp://ftp.freetds.org/pub/freetds/current/freetds-dev.0.99.678.tar.gz'}
 FREETDS_VERSION_INFO['0.95'] = {files: 'ftp://ftp.freetds.org/pub/freetds/stable/freetds-0.95.92.tar.gz'}

--- a/ext/tiny_tds/extconsts.rb
+++ b/ext/tiny_tds/extconsts.rb
@@ -5,12 +5,13 @@ ICONV_SOURCE_URI = "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{ICONV_VERSION
 OPENSSL_VERSION = ENV['TINYTDS_OPENSSL_VERSION'] || '1.0.2j'
 OPENSSL_SOURCE_URI = "https://www.openssl.org/source/openssl-#{OPENSSL_VERSION}.tar.gz"
 
+FREETDS_MIRROR_URI =
+  'ftp://ftp.freetds.org/pub/freetds/stable/freetds-%s.tar.bz2'
+# 'https://fossies.org/linux/privat/freetds-%s.tar.gz'
+
 FREETDS_VERSION = ENV['TINYTDS_FREETDS_VERSION'] || "1.00.26"
 FREETDS_VERSION_INFO = Hash.new { |h,k|
-  h[k] = {files: "ftp://ftp.freetds.org/pub/freetds/stable/freetds-#{k}.tar.bz2"}
+  h[k] = {files: FREETDS_MIRROR_URI % [FREETDS_VERSION] }
 }
 FREETDS_VERSION_INFO['1.00.26'] = {files: 'https://fossies.org/linux/privat/freetds-1.00.26.tar.gz'}
-FREETDS_VERSION_INFO['1.00'] = {files: 'ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.00.tar.bz2'}
-FREETDS_VERSION_INFO['0.99'] = {files: 'ftp://ftp.freetds.org/pub/freetds/current/freetds-dev.0.99.678.tar.gz'}
-FREETDS_VERSION_INFO['0.95'] = {files: 'ftp://ftp.freetds.org/pub/freetds/stable/freetds-0.95.92.tar.gz'}
 FREETDS_SOURCE_URI = FREETDS_VERSION_INFO[FREETDS_VERSION][:files]

--- a/test/bin/install-freetds.sh
+++ b/test/bin/install-freetds.sh
@@ -3,12 +3,28 @@
 set -x
 set -e
 
+constants=$(
+    ruby -r "./ext/tiny_tds/extconsts.rb" \
+         -e 'puts "FREETDS_VERSION=#{FREETDS_VERSION}"' \
+         -e 'puts "FREETDS_SOURCE_URI=#{FREETDS_SOURCE_URI}"'
+)
+
 if [ -z "$FREETDS_VERSION" ]; then
-  FREETDS_VERSION=$(ruby -r "./ext/tiny_tds/extconsts.rb" -e "puts FREETDS_VERSION")
+  eval $(echo $constants | grep "FREETDS_VERSION")
+fi
+if [ -z "$FREETDS_SOURCE_URI" ]; then
+    eval $(echo $constants | grep "FREETDS_SOURCE_URI")
 fi
 
-wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-$FREETDS_VERSION.tar.gz
-tar -xzf freetds-$FREETDS_VERSION.tar.gz
+wget "$FREETDS_SOURCE_URI"
+filename=$(basename $FREETDS_SOURCE_URI)
+
+case "$FREETDS_SOURCE_URI" in
+    *.tar.gz) tar -xzf $filename ;;
+    *.tar.bz2) tar -xjf $filename ;;
+    *) echo "unknown file type: $filename"
+esac
+
 cd freetds-$FREETDS_VERSION
 ./configure --prefix=/opt/local \
             --with-openssl=/opt/local \
@@ -17,4 +33,4 @@ make
 make install
 cd ..
 rm -rf freetds-$FREETDS_VERSION
-rm freetds-$FREETDS_VERSION.tar.gz
+rm $filename


### PR DESCRIPTION
ftp://ftp.freetds.org has been down over a day.

This is a workaround to change the mirror (same one used by [homebrew's freetds formula][1]) for the current version of _freetds_ in order to fix broken builds.

I've also made the configuration a little more flexible to be able to change the source in the future if needed. (Maybe we could make this a list of mirrors to fall back on: I haven't investigated that yet.)

[1]: https://github.com/Homebrew/homebrew-core/blob/master/Formula/freetds.rb