### PR TITLE
Info Messages

### DIFF
--- a/ext/tiny_tds/client.c
+++ b/ext/tiny_tds/client.c
@@ -3,10 +3,11 @@
 
 VALUE cTinyTdsClient;
 extern VALUE mTinyTds, cTinyTdsError;
-static ID sym_username, sym_password, sym_dataserver, sym_database, sym_appname, sym_tds_version, sym_login_timeout, sym_timeout, sym_encoding, sym_azure, sym_contained, sym_use_utf16;
+static ID sym_username, sym_password, sym_dataserver, sym_database, sym_appname, sym_tds_version, sym_login_timeout, sym_timeout, sym_encoding, sym_azure, sym_contained, sym_use_utf16, sym_message_handler;
 static ID intern_source_eql, intern_severity_eql, intern_db_error_number_eql, intern_os_error_number_eql;
-static ID intern_new, intern_dup, intern_transpose_iconv_encoding, intern_local_offset, intern_gsub;
+static ID intern_new, intern_dup, intern_transpose_iconv_encoding, intern_local_offset, intern_gsub, intern_call;
 VALUE opt_escape_regex, opt_escape_dblquote;
+VALUE message_handler;
 
 
 // Lib Macros
@@ -24,7 +25,7 @@ VALUE opt_escape_regex, opt_escape_dblquote;
 
 // Lib Backend (Helpers)
 
-VALUE rb_tinytds_raise_error(DBPROCESS *dbproc, int cancel, const char *error, const char *source, int severity, int dberr, int oserr) {
+VALUE rb_tinytds_raise_error(DBPROCESS *dbproc, int is_message, int cancel, const char *error, const char *source, int severity, int dberr, int oserr) {
   VALUE e;
   GET_CLIENT_USERDATA(dbproc);
   if (cancel && !dbdead(dbproc) && userdata && !userdata->closed) {
@@ -41,6 +42,15 @@ VALUE rb_tinytds_raise_error(DBPROCESS *dbproc, int cancel, const char *error, c
     rb_funcall(e, intern_db_error_number_eql, 1, INT2FIX(dberr));
   if (oserr)
     rb_funcall(e, intern_os_error_number_eql, 1, INT2FIX(oserr));
+
+  if (severity <= 10 && is_message) {
+    if (message_handler && message_handler != Qnil && rb_respond_to(message_handler, intern_call) != 0) {
+      rb_funcall(message_handler, intern_call, 1, e);
+    }
+
+    return Qnil;
+  }
+
   rb_exc_raise(e);
   return Qnil;
 }
@@ -109,6 +119,7 @@ int tinytds_err_handler(DBPROCESS *dbproc, int severity, int dberr, int oserr, c
     generic message can be sent.
     */
     if (!userdata->nonblocking_error.is_set) {
+      userdata->nonblocking_error.is_message = 0;
       userdata->nonblocking_error.cancel = cancel;
       strncpy(userdata->nonblocking_error.error, dberrstr, ERROR_MSG_SIZE);
       strncpy(userdata->nonblocking_error.source, source, ERROR_MSG_SIZE);
@@ -119,7 +130,7 @@ int tinytds_err_handler(DBPROCESS *dbproc, int severity, int dberr, int oserr, c
     }
 
   } else {
-    rb_tinytds_raise_error(dbproc, cancel, dberrstr, source, severity, dberr, oserr);
+    rb_tinytds_raise_error(dbproc, 0, cancel, dberrstr, source, severity, dberr, oserr);
   }
 
   return return_value;
@@ -128,25 +139,28 @@ int tinytds_err_handler(DBPROCESS *dbproc, int severity, int dberr, int oserr, c
 int tinytds_msg_handler(DBPROCESS *dbproc, DBINT msgno, int msgstate, int severity, char *msgtext, char *srvname, char *procname, int line) {
   static const char *source = "message";
   GET_CLIENT_USERDATA(dbproc);
-  if (severity > 10) {
-    // See tinytds_err_handler() for info about why we do this
-    if (userdata && userdata->nonblocking) {
-      if (!userdata->nonblocking_error.is_set) {
-        userdata->nonblocking_error.cancel = 1;
-        strncpy(userdata->nonblocking_error.error, msgtext, ERROR_MSG_SIZE);
-        strncpy(userdata->nonblocking_error.source, source, ERROR_MSG_SIZE);
-        userdata->nonblocking_error.severity = severity;
-        userdata->nonblocking_error.dberr = msgno;
-        userdata->nonblocking_error.oserr = msgstate;
-        userdata->nonblocking_error.is_set = 1;
-      }
-      if (!dbdead(dbproc) && !userdata->closed) {
-        dbcancel(dbproc);
-        userdata->dbcancel_sent = 1;
-      }
-    } else {
-      rb_tinytds_raise_error(dbproc, 1, msgtext, source, severity, msgno, msgstate);
+
+  int is_message_an_error = severity > 10 ? 1 : 0;
+
+  // See tinytds_err_handler() for info about why we do this
+  if (userdata && userdata->nonblocking) {
+    if (!userdata->nonblocking_error.is_set) {
+      userdata->nonblocking_error.is_message = !is_message_an_error;
+      userdata->nonblocking_error.cancel = is_message_an_error;
+      strncpy(userdata->nonblocking_error.error, msgtext, ERROR_MSG_SIZE);
+      strncpy(userdata->nonblocking_error.source, source, ERROR_MSG_SIZE);
+      userdata->nonblocking_error.severity = severity;
+      userdata->nonblocking_error.dberr = msgno;
+      userdata->nonblocking_error.oserr = msgstate;
+      userdata->nonblocking_error.is_set = 1;
     }
+
+    if (is_message_an_error && !dbdead(dbproc) && !userdata->closed) {
+      dbcancel(dbproc);
+      userdata->dbcancel_sent = 1;
+    }
+  } else {
+    rb_tinytds_raise_error(dbproc, !is_message_an_error, is_message_an_error, msgtext, source, severity, msgno, msgstate);
   }
   return 0;
 }
@@ -308,6 +322,7 @@ static VALUE rb_tinytds_connect(VALUE self, VALUE opts) {
   azure = rb_hash_aref(opts, sym_azure);
   contained = rb_hash_aref(opts, sym_contained);
   use_utf16 = rb_hash_aref(opts, sym_use_utf16);
+  message_handler = rb_hash_aref(opts, sym_message_handler);
   /* Dealing with options. */
   if (dbinit() == FAIL) {
     rb_raise(cTinyTdsError, "failed dbinit() function");
@@ -352,6 +367,7 @@ static VALUE rb_tinytds_connect(VALUE self, VALUE opts) {
       rb_warn("TinyTds: :use_utf16 option not supported in this version of FreeTDS.\n");
     }
   #endif
+
   cwrap->client = dbopen(cwrap->login, StringValueCStr(dataserver));
   if (cwrap->client) {
     VALUE transposed_encoding;
@@ -410,6 +426,7 @@ void init_tinytds_client() {
   sym_azure = ID2SYM(rb_intern("azure"));
   sym_contained = ID2SYM(rb_intern("contained"));
   sym_use_utf16 = ID2SYM(rb_intern("use_utf16"));
+  sym_message_handler = ID2SYM(rb_intern("message_handler"));
   /* Intern TinyTds::Error Accessors */
   intern_source_eql = rb_intern("source=");
   intern_severity_eql = rb_intern("severity=");
@@ -421,6 +438,7 @@ void init_tinytds_client() {
   intern_transpose_iconv_encoding = rb_intern("transpose_iconv_encoding");
   intern_local_offset = rb_intern("local_offset");
   intern_gsub = rb_intern("gsub");
+  intern_call = rb_intern("call");
   /* Escape Regexp Global */
   opt_escape_regex = rb_funcall(rb_cRegexp, intern_new, 1, rb_str_new2("\\\'"));
   opt_escape_dblquote = rb_str_new2("''");

--- a/ext/tiny_tds/client.h
+++ b/ext/tiny_tds/client.h
@@ -8,6 +8,7 @@ void init_tinytds_client();
 
 typedef struct {
   short int is_set;
+  int is_message;
   int cancel;
   char error[ERROR_MSG_SIZE];
   char source[ERROR_MSG_SIZE];
@@ -38,7 +39,7 @@ typedef struct {
   rb_encoding *encoding;
 } tinytds_client_wrapper;
 
-VALUE rb_tinytds_raise_error(DBPROCESS *dbproc, int cancel, const char *error, const char *source, int severity, int dberr, int oserr);
+VALUE rb_tinytds_raise_error(DBPROCESS *dbproc, int is_message, int cancel, const char *error, const char *source, int severity, int dberr, int oserr);
 
 // Lib Macros
 

--- a/ext/tiny_tds/result.c
+++ b/ext/tiny_tds/result.c
@@ -98,6 +98,7 @@ static void nogvl_cleanup(DBPROCESS *client) {
   if (userdata->nonblocking_error.is_set) {
     userdata->nonblocking_error.is_set = 0;
     rb_tinytds_raise_error(client,
+      userdata->nonblocking_error.is_message,
       userdata->nonblocking_error.cancel,
       userdata->nonblocking_error.error,
       userdata->nonblocking_error.source,

--- a/lib/tiny_tds/client.rb
+++ b/lib/tiny_tds/client.rb
@@ -10,6 +10,7 @@ module TinyTds
     }
 
     attr_reader :query_options
+    attr_reader :message_handler
 
     class << self
 
@@ -37,6 +38,12 @@ module TinyTds
       if opts[:dataserver].to_s.empty? && opts[:host].to_s.empty?
         raise ArgumentError, 'missing :host option if no :dataserver given'
       end
+
+      @message_handler = opts[:message_handler] || (block_given? ? Proc.new : nil)
+      if @message_handler && !@message_handler.respond_to?(:call)
+        raise ArgumentError, ':message_handler must implement `call` (eg, a Proc or a Method)'
+      end
+
       opts[:username] = parse_username(opts)
       @query_options = self.class.default_query_options.dup
       opts[:password] = opts[:password].to_s if opts[:password] && opts[:password].to_s.strip != ''

--- a/lib/tiny_tds/client.rb
+++ b/lib/tiny_tds/client.rb
@@ -39,7 +39,7 @@ module TinyTds
         raise ArgumentError, 'missing :host option if no :dataserver given'
       end
 
-      @message_handler = opts[:message_handler] = opts[:message_handler] || (block_given? ? Proc.new : nil)
+      @message_handler = opts[:message_handler]
       if @message_handler && !@message_handler.respond_to?(:call)
         raise ArgumentError, ':message_handler must implement `call` (eg, a Proc or a Method)'
       end

--- a/lib/tiny_tds/client.rb
+++ b/lib/tiny_tds/client.rb
@@ -39,7 +39,7 @@ module TinyTds
         raise ArgumentError, 'missing :host option if no :dataserver given'
       end
 
-      @message_handler = opts[:message_handler] || (block_given? ? Proc.new : nil)
+      @message_handler = opts[:message_handler] = opts[:message_handler] || (block_given? ? Proc.new : nil)
       if @message_handler && !@message_handler.respond_to?(:call)
         raise ArgumentError, ':message_handler must implement `call` (eg, a Proc or a Method)'
       end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -59,7 +59,7 @@ class ClientTest < TinyTds::TestCase
     end
 
     it 'must be able to use :host/:port connection' do
-      host = ENV['TINYTDS_UNIT_HOST_TEST'] || ENV['TINYTDS_UNIT_HOST']
+      host = ENV['TINYTDS_UNIT_HOST_TEST'] || ENV['TINYTDS_UNIT_HOST'] || 'localhost'
       port = ENV['TINYTDS_UNIT_PORT_TEST'] || ENV['TINYTDS_UNIT_PORT'] || 1433
       begin
         client = new_connection dataserver: nil, host: host, port: port

--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -642,6 +642,17 @@ class ResultTest < TinyTds::TestCase
             end
           end
 
+          it 'calls the provided message handler for `print` messages' do
+            messages.clear
+
+            msg = 'hello'
+            @client.execute("PRINT '#{msg}'").do
+
+            m = messages.first
+            assert_equal 1, messages.length, 'there should be one message after one print statement'
+            assert_equal msg, m.message, 'message text'
+          end
+
         end
 
         it 'must not raise an error when severity is 10 or less' do

--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -637,7 +637,7 @@ class ResultTest < TinyTds::TestCase
               m = messages.first
               assert_equal 1, messages.length, 'there should be one message after one raiserror'
               assert_equal msg, m.message, 'message text'
-              assert_equal severity, m.severity, 'message severity'
+              assert_equal severity, m.severity, 'message severity' unless severity == 10 && m.severity.to_i == 0
               assert_equal state, m.os_error_number, 'message state'
             end
           end

--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -654,48 +654,6 @@ class ResultTest < TinyTds::TestCase
           end
         end
 
-        describe 'using an initializer block' do
-          let(:messages) { Array.new }
-
-          before do
-            close_client
-            @client = new_connection do |m|
-              messages << m
-            end
-          end
-
-          after do
-            messages.clear
-          end
-
-          it 'has a message handler that responds to call' do
-            assert @client.message_handler.respond_to?(:call)
-          end
-
-          it 'calls the provided message handler when severity is 10 or less' do
-            (1..10).to_a.each do |severity|
-              messages.clear
-              msg = "Test #{severity} severity"
-              state = rand(1..255)
-              @client.execute("RAISERROR(N'#{msg}', #{severity}, #{state})").do
-              m = messages.first
-              assert_equal 1, messages.length, 'there should be one message after one raiserror'
-              assert_equal msg, m.message, 'message text'
-              assert_equal severity, m.severity, 'message severity' unless severity == 10 && m.severity.to_i == 0
-              assert_equal state, m.os_error_number, 'message state'
-            end
-          end
-
-          it 'calls the provided message handler for `print` messages' do
-            messages.clear
-            msg = 'hello'
-            @client.execute("PRINT '#{msg}'").do
-            m = messages.first
-            assert_equal 1, messages.length, 'there should be one message after one print statement'
-            assert_equal msg, m.message, 'message text'
-          end
-        end
-
         it 'must not raise an error when severity is 10 or less' do
           (1..10).to_a.each do |severity|
             @client.execute("RAISERROR(N'Test #{severity} severity', #{severity}, 1)").do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,8 +48,8 @@ module TinyTds
       client.close if defined?(client) && client.is_a?(TinyTds::Client)
     end
 
-    def new_connection(options={})
-      client = TinyTds::Client.new(connection_options(options))
+    def new_connection(options={}, &blk)
+      client = TinyTds::Client.new(connection_options(options), &blk)
       if sybase_ase?
         client.execute("SET ANSINULL ON").do
         return client

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,8 +48,8 @@ module TinyTds
       client.close if defined?(client) && client.is_a?(TinyTds::Client)
     end
 
-    def new_connection(options={}, &blk)
-      client = TinyTds::Client.new(connection_options(options), &blk)
+    def new_connection(options={})
+      client = TinyTds::Client.new(connection_options(options))
       if sybase_ase?
         client.execute("SET ANSINULL ON").do
         return client

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -75,8 +75,8 @@ module TinyTds
       username = (sqlserver_azure? ? ENV['TINYTDS_UNIT_AZURE_USER'] : ENV['TINYTDS_UNIT_USER']) || 'tinytds'
       password = (sqlserver_azure? ? ENV['TINYTDS_UNIT_AZURE_PASS'] : ENV['TINYTDS_UNIT_PASS']) || ''
       { :dataserver    => sqlserver_azure? ? nil : ENV['TINYTDS_UNIT_DATASERVER'],
-        :host          => ENV['TINYTDS_UNIT_HOST'],
-        :port          => ENV['TINYTDS_UNIT_PORT'],
+        :host          => ENV['TINYTDS_UNIT_HOST'] || 'localhost',
+        :port          => ENV['TINYTDS_UNIT_PORT'] || '1433',
         :tds_version   => ENV['TINYTDS_UNIT_VERSION'],
         :username      => username,
         :password      => password,


### PR DESCRIPTION
### Problem

I work on a codebase that makes extensive use of info messages (eg, raiserror with a serverity level <= 10, such as `raiserror('hello world', 10 -1)`). I need to receive these info messages in ruby code, but until now TinyTds did not expose an API for this.

### Solution

See updated iteration below

<details>
I have improved TinyTDS's to handle info messages, and introduced an experimental API to expose messages to users. This PR includes an improvement to the C code that handles errors with severity <= 10, and Ruby code that exposes messages to users.

The current philosophy of this project is to handle messages like errors. This PR does not change that perspective. Info messages are simply instances of `TinyTDS::Error`s but instead of throwing an exception, they're channeled through the new API. There is no pressing need to refactor the message handling part of TinyTDS. My PR here is an intentionally small diff on top of the existing codebase to fix my specific problem.

Here's what the current experimental iteration new API looks like for users:

```ruby
opts = { hostname: ..., username: ..., password: ... }

# optionally pass a block to the initializer
# it will be invoked for messages not associated with an #execute call
client = TinyTds::Client.new opts do |m|
  puts "connection message: #{m.inspect}"
end

result = @client.execute 'use demo_database; exec msg_test; use master;'

# optionally pass a block to a new #receive_message method
# it will be invoked for messages associated with these results
result.receive_message do |m|
  puts "result message: #{m.inspect}"
end

# unchanged: normal result record access
each_opts = { cache_rows: false }
result.each_with_index(each_opts) do |record, i|
  puts "record: #{i} #{record.inspect}"
end
```

This sample program calls the following test sp and prints the resulting output:

```sql
create procedure msg_test
as
begin
	
	raiserror('one', 10, -1)
	raiserror('two', 10, -1)
	
	select 1 x
	
	raiserror('three', 10, -1)
	raiserror('four', 10, -1)
	
	select 2 x
	
	raiserror('five', 10, -1)
	raiserror('six', 10, -1)

end
go
```

```
$ ruby .\tiny_test.rb
connection message: #<TinyTds::Error: Changed database context to 'master'.>
connection message: #<TinyTds::Error: Changed language setting to us_english.>
result message: #<TinyTds::Error: Changed database context to 'demo_database'.>
result message: #<TinyTds::Error: one>
result message: #<TinyTds::Error: two>
record: 0 {"x"=>1}
result message: #<TinyTds::Error: three>
result message: #<TinyTds::Error: four>
record: 1 {"x"=>2}
result message: #<TinyTds::Error: five>
result message: #<TinyTds::Error: six>
result message: #<TinyTds::Error: Changed database context to 'master'.>
```

### Ergonomics & Open Questions

1. It's kind of weird to have an `Error` object that you don't plan on using to raise an exception with, but I think it makes sense in this situation.
    - I considered making `TinyTDS::Message < Error`, but it seemed needlessly redundant.

2. There an question of whether info messages are more like results or more like events.
    - I prefer the event-like model, because it is (relatively) simple to implement a fire-and-forget model from C, and it also more easily enables interleaving messages & results.
    - The results-like model would look like having a `client.messages` array, where new messages are pushed on as they are received. This could be mutable by both the user and C code, so the user could do something like `client.messages.pop`. But ugh, more state management.

3. Fundamentally, messages are coming from the "connection" context, not the "result" context. Making it easy to get info messages "from results" is a fake abstraction.
    - My current thinking is that it's useful to do this, but it does require some additional ruby code in this PR. Basically, a reference to the most recent results object is kept, and if present, messages are sent to it. Otherwise, messages are handled by the client object. I think it's a lot more useful to receive messages in the context of loading result records, as they often go together. Also, in my current use of TinyTDS is, the connection is instantiated in one section of the code but `#execute` is called in another place. If the ONLY way to get messages is right next to `TinyTDS::Client.new`, that's going to result in me doing awkward gymnastics to get results & messages together. However with the current experimental API, I can get messages right next to results.
    - This is probably the biggest thing requiring feedback. I've not fully decided my own opinion on this yet, either.

### Things to review

What's the feeling on the following:

* Keeping an object instance reference around when the db client is set up (that is `VALUE TinyTdsInstance;` in C)
* Keeping a reference to the most recent results object around, so we can forward messages to it?
* Forwarding messages to the most recent results at all?
* Passing a block to the client initializer?

</details>