### PR TITLE
Support the FREETDS_DIR environment variable

### DIFF
--- a/ext/tiny_tds/extconf.rb
+++ b/ext/tiny_tds/extconf.rb
@@ -23,15 +23,25 @@ do_help if arg_config('--help')
 # Make sure to check the ports path for the configured host
 host = RbConfig::CONFIG['host']
 project_dir = File.join(['..']*4)
-freetds_dir = File.join(project_dir, 'ports', host, 'freetds', FREETDS_VERSION)
-freetds_dir = File.expand_path(freetds_dir)
+freetds_ports_dir = File.join(project_dir, 'ports', host, 'freetds', FREETDS_VERSION)
+freetds_ports_dir = File.expand_path(freetds_ports_dir)
 
 # Add all the special path searching from the original tiny_tds build
 # order is important here! First in, last searched.
-%w(
+DIRS = %w(
   /usr/local
   /opt/local
-).each do |path|
+)
+
+# Grab freetds environment variable for use by people on services like
+# Heroku who they can't easily use bundler config to set directories
+DIRS.push(ENV['FREETDS_DIR']) if ENV.has_key?('FREETDS_DIR')
+
+# Add the ports directory if it exists for local developer builds
+DIRS.push(freetds_ports_dir) if File.directory?(freetds_ports_dir)
+
+# Add the search paths for freetds configured above
+DIRS.each do |path|
   idir = "#{path}/include"
   ldir = "#{path}/lib"
 
@@ -39,12 +49,6 @@ freetds_dir = File.expand_path(freetds_dir)
     [idir, "#{idir}/freetds"],
     [ldir, "#{ldir}/freetds"]
   )
-end
-
-# Add the ports directory if it exists for local developer builds
-if File.directory?(freetds_dir)
-  puts "Using freetds port path #{freetds_dir}"
-  dir_config('freetds', "#{freetds_dir}/include", "#{freetds_dir}/lib")
 end
 
 have_dependencies = [


### PR DESCRIPTION
This commit adds support for the FREETDS_DIR environment variable as an
alternative to configuring the freetds path via bundle config. This
eases configuration in environments like Heroku where configuration via
bundle config just isn't possible. This fixes a likely regression
caused by the miniportile build refactor.

Relates to issue #371