### PR TITLE
Use official HTTP mirrors instead of FTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ apt-get wget
 $ apt-get install build-essential
 $ apt-get install libc6-dev
 
-$ wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.00.21.tar.gz
+$ wget http://www.freetds.org/files/stable/freetds-1.00.21.tar.gz
 $ tar -xzf freetds-1.00.21.tar.gz
 $ cd freetds-1.00.21
 $ ./configure --prefix=/usr/local --with-tdsver=7.3

--- a/ext/tiny_tds/extconsts.rb
+++ b/ext/tiny_tds/extconsts.rb
@@ -7,9 +7,9 @@ OPENSSL_SOURCE_URI = "https://www.openssl.org/source/openssl-#{OPENSSL_VERSION}.
 
 FREETDS_VERSION = ENV['TINYTDS_FREETDS_VERSION'] || "1.00.27"
 FREETDS_VERSION_INFO = Hash.new { |h,k|
-  h[k] = {files: "ftp://ftp.freetds.org/pub/freetds/stable/freetds-#{k}.tar.bz2"}
+  h[k] = {files: "http://www.freetds.org/files/stable/freetds-#{k}.tar.bz2"}
 }
-FREETDS_VERSION_INFO['1.00'] = {files: 'ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.00.tar.bz2'}
-FREETDS_VERSION_INFO['0.99'] = {files: 'ftp://ftp.freetds.org/pub/freetds/current/freetds-dev.0.99.678.tar.gz'}
-FREETDS_VERSION_INFO['0.95'] = {files: 'ftp://ftp.freetds.org/pub/freetds/stable/freetds-0.95.92.tar.gz'}
+FREETDS_VERSION_INFO['1.00'] = {files: 'http://www.freetds.org/files/stable/freetds-1.00.tar.bz2'}
+FREETDS_VERSION_INFO['0.99'] = {files: 'http://www.freetds.org/files/current/freetds-dev.0.99.678.tar.gz'}
+FREETDS_VERSION_INFO['0.95'] = {files: 'http://www.freetds.org/files/stable/freetds-0.95.92.tar.gz'}
 FREETDS_SOURCE_URI = FREETDS_VERSION_INFO[FREETDS_VERSION][:files]

--- a/test/bin/install-freetds.sh
+++ b/test/bin/install-freetds.sh
@@ -7,7 +7,7 @@ if [ -z "$FREETDS_VERSION" ]; then
   FREETDS_VERSION=$(ruby -r "./ext/tiny_tds/extconsts.rb" -e "puts FREETDS_VERSION")
 fi
 
-wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-$FREETDS_VERSION.tar.gz
+wget http://www.freetds.org/files/stable/freetds-$FREETDS_VERSION.tar.gz
 tar -xzf freetds-$FREETDS_VERSION.tar.gz
 cd freetds-$FREETDS_VERSION
 ./configure --prefix=/opt/local \


### PR DESCRIPTION
This is related to #372 - The FreeTDS maintainers have officially added support for HTTP downloads. 