### PR TITLE
Add support for "application intent read only"

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Creating a new client takes a hash of options. For valid iconv encoding options,
 * :contained - Pass true to signal that you are connecting with a contained database user.
 * :use_utf16 - Instead of using UCS-2 for database wide character encoding use UTF-16. Newer Windows versions use this encoding instead of UCS-2. Default true.
 * :message_handler - Pass in a `call`-able object such as a `Proc` or a method to receive info messages from the database. It should have a single parameter, which will be a `TinyTds::Error` object representing the message. For example:
+* :application_intent - When connecting to an Availability Group, pass `:read_only` to connect to a read replica (Note: the `:database` option must also be set to a database joined to the AG that has a read replica). Defaults to `nil`.
 
 ```ruby
 opts = ... # host, username, password, etc

--- a/ext/tiny_tds/client.c
+++ b/ext/tiny_tds/client.c
@@ -345,7 +345,7 @@ static VALUE rb_tinytds_connect(VALUE self, VALUE opts) {
   if (!NIL_P(charset))
     DBSETLCHARSET(cwrap->login, StringValueCStr(charset));
   if (!NIL_P(database)) {
-    if (azure == Qtrue || contained == Qtrue) {
+    if (azure == Qtrue || contained == Qtrue || read_only_intent == Qtrue) {
       #ifdef DBSETLDBNAME
         DBSETLDBNAME(cwrap->login, StringValueCStr(database));
       #else
@@ -354,6 +354,9 @@ static VALUE rb_tinytds_connect(VALUE self, VALUE opts) {
         }
         if (contained == Qtrue) {
           rb_warn("TinyTds: :contained option is not supported in this version of FreeTDS.\n");
+        }
+        if (read_only_intent == Qtrue) {
+          rb_warn("TinyTds: this version of FreeTDS doesn't support setting the login database.\n");
         }
       #endif
     }

--- a/ext/tiny_tds/client.c
+++ b/ext/tiny_tds/client.c
@@ -371,8 +371,12 @@ static VALUE rb_tinytds_connect(VALUE self, VALUE opts) {
   #endif
 
   #ifdef DBSETREADONLY
-    if (read_only_intent == Qtrue) {
-      DBSETLREADONLY(cwrap->login, 1);
+    if (version < 7.4) {
+      rb_warn("TinyTds: :read_only_intent requires TDS 7.4 or greater.\n");
+    } else {
+      if (read_only_intent == Qtrue) {
+        DBSETLREADONLY(cwrap->login, 1);
+      }
     }
   #else
     if (read_only_intent == Qtrue || read_only_intent == Qfalse) {

--- a/lib/tiny_tds/client.rb
+++ b/lib/tiny_tds/client.rb
@@ -50,6 +50,7 @@ module TinyTds
       opts[:appname] ||= 'TinyTds'
       opts[:tds_version] = tds_versions_setter(opts)
       opts[:use_utf16] = opts[:use_utf16].nil? || ["true", "1", "yes"].include?(opts[:use_utf16].to_s)
+      opts[:read_only_intent] = opts[:read_only_intent].nil? ? nil : ["true", "1", "yes"].include?(opts[:read_only_intent].to_s)
       opts[:login_timeout] ||= 60
       opts[:timeout] ||= 5
       opts[:encoding] = opts[:encoding].nil? || opts[:encoding].casecmp('utf8').zero? ? 'UTF-8' : opts[:encoding].upcase

--- a/lib/tiny_tds/client.rb
+++ b/lib/tiny_tds/client.rb
@@ -87,7 +87,7 @@ module TinyTds
     end
 
     def tds_versions_setter(opts = {})
-      v = opts[:tds_version] || ENV['TDSVER'] || '7.3'
+      v = opts[:tds_version] || ENV['TDSVER'] || '7.4'
       TDS_VERSIONS_SETTERS[v.to_s]
     end
 
@@ -110,7 +110,8 @@ module TinyTds
       '90'      => 6,
       '9.0'     => 6,
       '73'      => 7,
-      '7.3'     => 7
+      '7.3'     => 7,
+      '7.4'     => 7
     }.freeze
 
     # From sybdb.h comments:

--- a/lib/tiny_tds/client.rb
+++ b/lib/tiny_tds/client.rb
@@ -50,7 +50,6 @@ module TinyTds
       opts[:appname] ||= 'TinyTds'
       opts[:tds_version] = tds_versions_setter(opts)
       opts[:use_utf16] = opts[:use_utf16].nil? || ["true", "1", "yes"].include?(opts[:use_utf16].to_s)
-      opts[:read_only_intent] = opts[:read_only_intent].nil? ? nil : ["true", "1", "yes"].include?(opts[:read_only_intent].to_s)
       opts[:login_timeout] ||= 60
       opts[:timeout] ||= 5
       opts[:encoding] = opts[:encoding].nil? || opts[:encoding].casecmp('utf8').zero? ? 'UTF-8' : opts[:encoding].upcase

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -75,7 +75,7 @@ class ClientTest < TinyTds::TestCase
       skip unless ENV['TINYTDS_READ_REPLICA_SERVER_NAME']
 
       begin
-        client = new_connection read_only_intent: true
+        client = new_connection application_intent: :read_only
         connected_to_server_name = client.execute('select @@servername server_name').to_a.first['server_name']
 
         assert_equal ENV['TINYTDS_READ_REPLICA_SERVER_NAME'], connected_to_server_name

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -70,6 +70,21 @@ class ClientTest < TinyTds::TestCase
 
   end
 
+  describe 'With custom options' do
+    it 'has an option for application intent read only' do
+      skip unless ENV['TINYTDS_READ_REPLICA_SERVER_NAME']
+
+      begin
+        client = new_connection read_only_intent: true
+        connected_to_server_name = client.execute('select @@servername server_name').to_a.first['server_name']
+
+        assert_equal ENV['TINYTDS_READ_REPLICA_SERVER_NAME'], connected_to_server_name
+      ensure
+        client.close if client
+      end
+    end
+  end
+
   describe 'With in-valid options' do
 
     it 'raises an argument error when no :host given and :dataserver is blank' do


### PR DESCRIPTION
Add support for "Application Intent Read Only" (https://github.com/rails-sqlserver/tiny_tds/issues/184). The use case is, when connecting to an availability group listener that has read only secondary replicas, the app can request to be connected to a replica rather than the primary.

Other than confirming that there's no regressions and the bit can be set, I'm not sure exactly how to write tests for this.... setting up multiple sql server docker containers just to set up an AG just to test this seems like overkill.