### PR TITLE
Update recommended minor version of FreeTDS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ env:
     - PATH=/opt/local/bin:$PATH
     - TESTOPTS="-v"
     - TINYTDS_UNIT_HOST=localhost
+dist:
+  - trusty
+  - xenial
 rvm:
   - 2.1.9
   - 2.2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,40 @@ matrix:
   include:
     - os: linux
       dist: trusty
+      rvm: 2.1.9
+      install:
+        - gem install bundler -v '<2'
+    - os: linux
+      dist: trusty
+      rvm: 2.2.5
+      install:
+        - gem install bundler -v '<2'
+    - os: linux
+      dist: trusty
+      rvm: 2.3.1
+      install:
+        - gem install bundler
     - os: linux
       dist: xenial
-rvm:
-  - 2.1.9
-  - 2.2.5
-  - 2.3.1
+      rvm: 2.1.9
+      install:
+        - gem install bundler -v '<2'
+    - os: linux
+      dist: xenial
+      rvm: 2.2.5
+      install:
+        - gem install bundler -v '<2'
+    - os: linux
+      dist: xenial
+      rvm: 2.3.1
+      install:
+        - gem install bundler
 before_install:
   - docker info
   - sudo ./test/bin/install-openssl.sh
   - sudo ./test/bin/install-freetds.sh
   - sudo ./test/bin/setup.sh
 install:
-  - gem install bundler
   - bundle --version
   - bundle install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,12 @@ env:
     - PATH=/opt/local/bin:$PATH
     - TESTOPTS="-v"
     - TINYTDS_UNIT_HOST=localhost
-dist:
-  - trusty
-  - xenial
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+    - os: linux
+      dist: xenial
 rvm:
   - 2.1.9
   - 2.2.5

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ $ apt-get install wget
 $ apt-get install build-essential
 $ apt-get install libc6-dev
 
-$ wget http://www.freetds.org/files/stable/freetds-1.00.21.tar.gz
-$ tar -xzf freetds-1.00.21.tar.gz
-$ cd freetds-1.00.21
+$ wget http://www.freetds.org/files/stable/freetds-1.00.110.tar.gz
+$ tar -xzf freetds-1.00.110.tar.gz
+$ cd freetds-1.00.110
 $ ./configure --prefix=/usr/local --with-tdsver=7.3
 $ make
 $ make install

--- a/ext/tiny_tds/extconsts.rb
+++ b/ext/tiny_tds/extconsts.rb
@@ -5,7 +5,7 @@ ICONV_SOURCE_URI = "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{ICONV_VERSION
 OPENSSL_VERSION = ENV['TINYTDS_OPENSSL_VERSION'] || '1.1.0e'
 OPENSSL_SOURCE_URI = "https://www.openssl.org/source/openssl-#{OPENSSL_VERSION}.tar.gz"
 
-FREETDS_VERSION = ENV['TINYTDS_FREETDS_VERSION'] || "1.00.27"
+FREETDS_VERSION = ENV['TINYTDS_FREETDS_VERSION'] || "1.00.110"
 FREETDS_VERSION_INFO = Hash.new { |h,k|
   h[k] = {files: "http://www.freetds.org/files/stable/freetds-#{k}.tar.bz2"}
 }


### PR DESCRIPTION
The readme currently suggests using a minor version of FreeTDS that is quite out of date and doesn't work with OpenSSL v1.1.0. OpenSSL v1.1.0 is the version installed on most modern operating systems so this can cause confusion for users.

Support for OpenSSL v1.1.0 was added in freetds-1.00.27, however the latest version is 1.00.110. Installation of tiny_tds seems to work fine with 1.00.110.