### PR TITLE
Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,21 +13,24 @@ matrix:
       rvm: 2.1.9
       install:
         - gem install bundler -v '<2'
+        - bundle --version
+        - bundle install
     - os: linux
       rvm: 2.2.5
       install:
         - gem install bundler -v '<2'
+        - bundle --version
+        - bundle install
     - os: linux
       rvm: 2.3.1
       install:
         - gem install bundler
+        - bundle --version
+        - bundle install
 before_install:
   - docker info
   - sudo ./test/bin/install-openssl.sh
   - sudo ./test/bin/install-freetds.sh
   - sudo ./test/bin/setup.sh
-install:
-  - bundle --version
-  - bundle install
 script:
   - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,26 @@ env:
     - PATH=/opt/local/bin:$PATH
     - TESTOPTS="-v"
     - TINYTDS_UNIT_HOST=localhost
-rvm:
-  - 2.1.9
-  - 2.2.5
-  - 2.3.1
+matrix:
+  include:
+    - os: linux
+      rvm: 2.1.9
+      install:
+        - gem install bundler -v '<2'
+    - os: linux
+      rvm: 2.2.5
+      install:
+        - gem install bundler -v '<2'
+    - os: linux
+      rvm: 2.3.1
+      install:
+        - gem install bundler
 before_install:
   - docker info
   - sudo ./test/bin/install-openssl.sh
   - sudo ./test/bin/install-freetds.sh
   - sudo ./test/bin/setup.sh
 install:
-  - gem install bundler
   - bundle --version
   - bundle install
 script:


### PR DESCRIPTION
Due to updates to the bundler gem making it incompatible with older versions of ruby, the build is broken. This change specifies a compatible version of bundler for older rubies, allowing the build to pass again.