### PR TITLE
Remove old Ruby version from CI config & cross build rake task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
     - TESTOPTS="-v"
     - TINYTDS_UNIT_HOST=localhost
 rvm:
-  - 2.3.8
   - 2.4.5
   - 2.5.3
   - 2.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## (unreleased)
+
+* Removed old/unused appveyor config
+* Remove old Rubies from CI & cross compile list
+* Add Ruby 2.6 to the cross compile list
+
 ## 2.1.2
 
 * Use Kernel.BigDecimal vs BigDecimal.new. Fixes #409.

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ The default is true and since FreeTDS v1.0 would do this as well.
 
 ## Compiling Gems for Windows
 
-For the convenience of Windows users, TinyTDS ships pre-compiled gems for Ruby 2.0, 2.1, 2.2, and 2.3 on Windows. In order to generate these gems, [rake-compiler-dock](https://github.com/rake-compiler/rake-compiler-dock) is used. This project provides a [Docker image](https://registry.hub.docker.com/u/larskanis/rake-compiler-dock/) with rvm, cross-compilers and a number of different target versions of Ruby.
+For the convenience of Windows users, TinyTDS ships pre-compiled gems for supported versions of Ruby on Windows. In order to generate these gems, [rake-compiler-dock](https://github.com/rake-compiler/rake-compiler-dock) is used. This project provides a [Docker image](https://registry.hub.docker.com/u/larskanis/rake-compiler-dock/) with rvm, cross-compilers and a number of different target versions of Ruby.
 
 Run the following rake task to compile the gems for Windows. This will check the availability of [Docker](https://www.docker.com/) (and boot2docker on Windows or OS-X) and will give some advice for download and installation. When docker is running, it will download the docker image (once-only) and start the build:
 

--- a/tasks/native_gem.rake
+++ b/tasks/native_gem.rake
@@ -8,7 +8,7 @@ task 'gem:windows' => ['ports:cross'] do
   build = ['bundle']
 
   # and finally build the native gem
-  build << 'rake cross native gem RUBY_CC_VERSION=2.5.0:2.4.0 CFLAGS="-Wall" MAKE="make -j`nproc`"'
+  build << 'rake cross native gem RUBY_CC_VERSION=2.6.0:2.5.0:2.4.0 CFLAGS="-Wall" MAKE="make -j`nproc`"'
 
   RakeCompilerDock.sh build.join(' && ')
 end

--- a/tasks/native_gem.rake
+++ b/tasks/native_gem.rake
@@ -8,7 +8,7 @@ task 'gem:windows' => ['ports:cross'] do
   build = ['bundle']
 
   # and finally build the native gem
-  build << 'rake cross native gem RUBY_CC_VERSION=2.5.0:2.4.0:2.3.0:2.2.2:2.1.6:2.0.0 CFLAGS="-Wall" MAKE="make -j`nproc`"'
+  build << 'rake cross native gem RUBY_CC_VERSION=2.5.0:2.4.0 CFLAGS="-Wall" MAKE="make -j`nproc`"'
 
   RakeCompilerDock.sh build.join(' && ')
 end


### PR DESCRIPTION
This is a prerequisite for https://github.com/rails-sqlserver/tiny_tds/issues/434 (per [comment](https://github.com/rails-sqlserver/tiny_tds/issues/434#issuecomment-485863370)). It's effectively a followup to https://github.com/rails-sqlserver/tiny_tds/pull/428.

Adding recent contributors for review.