### PR TITLE
Update cross build, Travis and Appveyor-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - 2.4.5
   - 2.5.3
   - 2.6.1
+  - 2.7.0
 before_install:
   - docker info
   - sudo ./test/bin/install-openssl.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
     - TESTOPTS="-v"
     - TINYTDS_UNIT_HOST=localhost
 rvm:
-  - 2.3.8
   - 2.4.5
   - 2.5.3
   - 2.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## (unreleased)
+
+* Removed old/unused appveyor config
+* Remove old Rubies from CI & cross compile list
+* Add Ruby 2.6 to the cross compile list
+
 ## 2.1.2
 
 * Use Kernel.BigDecimal vs BigDecimal.new. Fixes #409.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Removed old/unused appveyor config
 * Remove old Rubies from CI & cross compile list
-* Add Ruby 2.6 to the cross compile list
+* Add Ruby 2.6 and 2.7 to the cross compile list
 
 ## 2.1.2
 

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ The default is true and since FreeTDS v1.0 would do this as well.
 
 ## Compiling Gems for Windows
 
-For the convenience of Windows users, TinyTDS ships pre-compiled gems for Ruby 2.0, 2.1, 2.2, and 2.3 on Windows. In order to generate these gems, [rake-compiler-dock](https://github.com/rake-compiler/rake-compiler-dock) is used. This project provides a [Docker image](https://registry.hub.docker.com/u/larskanis/rake-compiler-dock/) with rvm, cross-compilers and a number of different target versions of Ruby.
+For the convenience of Windows users, TinyTDS ships pre-compiled gems for supported versions of Ruby on Windows. In order to generate these gems, [rake-compiler-dock](https://github.com/rake-compiler/rake-compiler-dock) is used. This project provides a [Docker image](https://registry.hub.docker.com/u/larskanis/rake-compiler-dock/) with rvm, cross-compilers and a number of different target versions of Ruby.
 
 Run the following rake task to compile the gems for Windows. This will check the availability of [Docker](https://www.docker.com/) (and boot2docker on Windows or OS-X) and will give some advice for download and installation. When docker is running, it will download the docker image (once-only) and start the build:
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ $ apt-get install wget
 $ apt-get install build-essential
 $ apt-get install libc6-dev
 
-$ wget http://www.freetds.org/files/stable/freetds-1.1.6.tar.gz
-$ tar -xzf freetds-1.1.6.tar.gz
-$ cd freetds-1.1.6
+$ wget http://www.freetds.org/files/stable/freetds-1.1.24.tar.gz
+$ tar -xzf freetds-1.1.24.tar.gz
+$ cd freetds-1.1.24
 $ ./configure --prefix=/usr/local --with-tdsver=7.3
 $ make
 $ make install
@@ -401,7 +401,7 @@ The default is true and since FreeTDS v1.0 would do this as well.
 
 ## Compiling Gems for Windows
 
-For the convenience of Windows users, TinyTDS ships pre-compiled gems for supported versions of Ruby on Windows. In order to generate these gems, [rake-compiler-dock](https://github.com/rake-compiler/rake-compiler-dock) is used. This project provides a [Docker image](https://registry.hub.docker.com/u/larskanis/rake-compiler-dock/) with rvm, cross-compilers and a number of different target versions of Ruby.
+For the convenience of Windows users, TinyTDS ships pre-compiled gems for supported versions of Ruby on Windows. In order to generate these gems, [rake-compiler-dock](https://github.com/rake-compiler/rake-compiler-dock) is used. This project provides several [Docker images](https://registry.hub.docker.com/u/larskanis/) with rvm, cross-compilers and a number of different target versions of Ruby.
 
 Run the following rake task to compile the gems for Windows. This will check the availability of [Docker](https://www.docker.com/) (and boot2docker on Windows or OS-X) and will give some advice for download and installation. When docker is running, it will download the docker image (once-only) and start the build:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,21 @@
 init:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
-  - SET PATH=C:\MinGW\msys\1.0\bin;%PATH%
   - SET RAKEOPT=-rdevkit
   - SET TESTOPTS='-v'
-  - SET MAKE=make V=1
+  - SET MAKE=make V=1 -j2
 clone_depth: 5
 skip_tags: true
 skip_branch_with_pr: true
 matrix:
-  fast_finish: true
+  fast_finish: false
 install:
   # Output debugging info
   - ps: Update-AppveyorBuild -Version "$(Get-Content $env:appveyor_build_folder\VERSION).$env:appveyor_build_number"
+  - ps: |
+      if ($env:ruby_version -like "*head*") {
+        $(new-object net.webclient).DownloadFile("https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-head/rubyinstaller-$env:ruby_version.exe", "$pwd/ruby-setup.exe")
+        cmd /c ruby-setup.exe /verysilent /dir=C:/Ruby$env:ruby_version
+      }
   - perl --version
   - ruby --version
   - gem --version
@@ -43,13 +47,9 @@ environment:
   TINYTDS_UNIT_AZURE_PASS:
     secure: fYKSKV4v+36OFQp2nZdX4DfUpgmy5cm0wuR73cgdmEk=
   matrix:
-    - ruby_version: "23-x64"
-    - ruby_version: "23"
-    - ruby_version: "24-x64"
     - ruby_version: "24"
     - ruby_version: "25-x64"
-    - ruby_version: "25"
-    - ruby_version: "26-x64"
     - ruby_version: "26"
+    - ruby_version: "head-x64"
 on_failure:
   - find -name compile.log | xargs cat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,8 @@ install:
   - ruby --version
   - gem --version
 
+  # prevent freetds to link to wrong ws2_32 lib on i686-w64-mingw32
+  - c:/msys64/usr/bin/rm /usr/lib/w32api/libws2_32.a
   # Set up project prerequisits
   - bundle install
   - bundle exec rake ports
@@ -52,4 +54,5 @@ environment:
     - ruby_version: "26"
     - ruby_version: "head-x64"
 on_failure:
+  - find -name config.log | xargs cat
   - find -name compile.log | xargs cat

--- a/ext/tiny_tds/extconsts.rb
+++ b/ext/tiny_tds/extconsts.rb
@@ -2,10 +2,10 @@
 ICONV_VERSION = ENV['TINYTDS_ICONV_VERSION'] || "1.15"
 ICONV_SOURCE_URI = "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{ICONV_VERSION}.tar.gz"
 
-OPENSSL_VERSION = ENV['TINYTDS_OPENSSL_VERSION'] || '1.1.0j'
+OPENSSL_VERSION = ENV['TINYTDS_OPENSSL_VERSION'] || '1.1.1d'
 OPENSSL_SOURCE_URI = "https://www.openssl.org/source/openssl-#{OPENSSL_VERSION}.tar.gz"
 
-FREETDS_VERSION = ENV['TINYTDS_FREETDS_VERSION'] || "1.00.27"
+FREETDS_VERSION = ENV['TINYTDS_FREETDS_VERSION'] || "1.1.24"
 FREETDS_VERSION_INFO = Hash.new { |h,k|
   h[k] = {files: "http://www.freetds.org/files/stable/freetds-#{k}.tar.bz2"}
 }

--- a/tasks/native_gem.rake
+++ b/tasks/native_gem.rake
@@ -8,7 +8,7 @@ task 'gem:windows' => ['ports:cross'] do
   build = ['bundle']
 
   # and finally build the native gem
-  build << 'rake cross native gem RUBY_CC_VERSION=2.5.0:2.4.0 CFLAGS="-Wall" MAKE="make -j`nproc`"'
+  build << 'rake cross native gem RUBY_CC_VERSION=2.6.0:2.5.0:2.4.0 CFLAGS="-Wall" MAKE="make -j`nproc`"'
 
   RakeCompilerDock.sh build.join(' && ')
 end

--- a/tasks/native_gem.rake
+++ b/tasks/native_gem.rake
@@ -8,7 +8,7 @@ task 'gem:windows' => ['ports:cross'] do
   build = ['bundle']
 
   # and finally build the native gem
-  build << 'rake cross native gem RUBY_CC_VERSION=2.5.0:2.4.0:2.3.0:2.2.2:2.1.6:2.0.0 CFLAGS="-Wall" MAKE="make -j`nproc`"'
+  build << 'rake cross native gem RUBY_CC_VERSION=2.5.0:2.4.0 CFLAGS="-Wall" MAKE="make -j`nproc`"'
 
   RakeCompilerDock.sh build.join(' && ')
 end

--- a/tasks/native_gem.rake
+++ b/tasks/native_gem.rake
@@ -8,7 +8,7 @@ task 'gem:windows' => ['ports:cross'] do
   build = ['bundle']
 
   # and finally build the native gem
-  build << 'rake cross native gem RUBY_CC_VERSION=2.6.0:2.5.0:2.4.0 CFLAGS="-Wall" MAKE="make -j`nproc`"'
+  build << 'rake cross native gem RUBY_CC_VERSION=2.7.0:2.6.0:2.5.0:2.4.0 CFLAGS="-Wall" MAKE="make -j`nproc`"'
 
   RakeCompilerDock.sh build.join(' && ')
 end

--- a/tasks/ports.rake
+++ b/tasks/ports.rake
@@ -12,6 +12,8 @@ namespace :ports do
   freetds = Ports::Freetds.new(FREETDS_VERSION)
 
   directory "ports"
+  CLEAN.include "ports/*mingw32*"
+  CLEAN.include "ports/*.installed"
 
   task :openssl, [:host] do |task, args|
     args.with_defaults(host: RbConfig::CONFIG['host'])
@@ -69,15 +71,13 @@ namespace :ports do
   task 'cross' do
     require 'rake_compiler_dock'
 
-    # make sure to install our bundle
-    build = ['bundle']
-
     # build the ports for all our cross compile hosts
     GEM_PLATFORM_HOSTS.each do |gem_platform, host|
+      # make sure to install our bundle
+      build = ['bundle']
       build << "rake ports:compile[#{host}] MAKE='make -j`nproc`'"
+      RakeCompilerDock.sh build.join(' && '), platform: gem_platform
     end
-
-    RakeCompilerDock.sh build.join(' && ')
   end
 end
 

--- a/tasks/ports.rake
+++ b/tasks/ports.rake
@@ -6,8 +6,6 @@ require_relative 'ports/openssl'
 require_relative 'ports/freetds'
 require_relative '../ext/tiny_tds/extconsts'
 
-OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE if defined? OpenSSL
-
 namespace :ports do
   openssl = Ports::Openssl.new(OPENSSL_VERSION)
   libiconv = Ports::Libiconv.new(ICONV_VERSION)

--- a/tasks/ports/openssl.rb
+++ b/tasks/ports/openssl.rb
@@ -27,27 +27,11 @@ module Ports
 
     private
 
-    def execute(action, command, options={})
-      # OpenSSL Requires Perl >= 5.10, while the Ruby devkit uses MSYS1 with Perl 5.8.8.
-      # To overcome this, prepend Git's usr/bin to the PATH.
-      # It has MSYS2 with a recent version of perl.
-      prev_path = ENV['PATH']
-      if host =~ /mingw/ && IO.popen(["perl", "-e", "print($])"], &:read).to_f < 5.010
-        git_perl = 'C:/Program Files/Git/usr/bin'
-        if File.directory?(git_perl)
-          ENV['PATH'] = "#{git_perl}#{File::PATH_SEPARATOR}#{ENV['PATH']}"
-          ENV['PERL'] = 'perl'
-        end
-      end
-
-      super
-      ENV['PATH'] = prev_path
-    end
-
     def configure_defaults
       opts = [
         'shared',
-        target_arch
+        target_arch,
+        "--openssldir=#{path}",
       ]
 
       if cross_build?

--- a/tiny_tds.gemspec
+++ b/tiny_tds.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mini_portile2', '~> 2.0'
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'rake-compiler', '~> 1.0'
-  s.add_development_dependency 'rake-compiler-dock', '~> 0.6.3'
+  s.add_development_dependency 'rake-compiler-dock', '~> 1.0'
   s.add_development_dependency 'minitest', '~> 5.6'
   s.add_development_dependency 'connection_pool', '~> 2.2'
 end

--- a/tiny_tds.gemspec
+++ b/tiny_tds.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0.0'
   s.metadata['msys2_mingw_dependencies'] = 'freetds'
   s.add_development_dependency 'mini_portile2', '~> 2.0'
-  s.add_development_dependency 'rake', '~> 10.4'
+  s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rake-compiler', '~> 1.0'
   s.add_development_dependency 'rake-compiler-dock', '~> 1.0'
   s.add_development_dependency 'minitest', '~> 5.6'


### PR DESCRIPTION
This PR includes #455 . It adds ruby versions 2.6 and 2.7 to Windows binary gems and updates and fixes Appveyor and Travis CI. It also adds ruby-head to Appveyor-CI. It removes rubies before 2.4 and some necessary workarounds. OpenSSL and FreeTDS are updated to the latest release versions.

Appveyor needs to be re-enabled for this repository to be effective.
