### PR TITLE
WIP: Enable appveyor CI run on pull requests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ init:
   - SET MAKE=make V=1 -j2
 clone_depth: 5
 skip_tags: true
-skip_branch_with_pr: true
+skip_branch_with_pr: false
 matrix:
   fast_finish: false
 install:


### PR DESCRIPTION
This was disabled in commit a4431c222bb935e10b0eb0dc5363e4fb866b90d9, but running tests on a PR is a very useful response for the committer.