### PR TITLE
Fix test warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,7 @@ Use both dbsetversion() vs. dbsetlversion. Partially reverts #62.
   safe to call Result#cancel over and over again.
 * Look for the syb headers only.
 * Fix minitest global matchers warnings.
+* Fix test warnings.
 
 
 ## 0.3.2

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -65,7 +65,6 @@ class ClientTest < TinyTds::TestCase
         client.close if client
       end
     end unless sqlserver_azure?
-
   end
 
   describe 'With in-valid options' do

--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -684,7 +684,7 @@ class ResultTest < TinyTds::TestCase
       end
 
       it 'throws an error when you execute another query with other results pending' do
-        result1 = @client.execute(@query1)
+        @client.execute(@query1)
         action = lambda { @client.execute(@query1) }
         assert_raise_tinytds_error(action) do |e|
           assert_match %r|with results pending|i, e.message

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -14,7 +14,7 @@ class SchemaTest < TinyTds::TestCase
     describe 'for shared types' do
 
       it 'casts bigint' do
-        assert_equal -9223372036854775807, find_value(11, :bigint)
+        assert_equal (-9223372036854775807), find_value(11, :bigint)
         assert_equal 9223372036854775806, find_value(12, :bigint)
       end
 
@@ -96,7 +96,7 @@ class SchemaTest < TinyTds::TestCase
       end
 
       it 'casts int' do
-        assert_equal -2147483647, find_value(151, :int)
+        assert_equal (-2147483647), find_value(151, :int)
         assert_equal 2147483646, find_value(152, :int)
       end
 
@@ -170,7 +170,7 @@ class SchemaTest < TinyTds::TestCase
       end
 
       it 'casts smallint' do
-        assert_equal -32767, find_value(241, :smallint)
+        assert_equal (-32767), find_value(241, :smallint)
         assert_equal 32766, find_value(242, :smallint)
       end
 
@@ -396,15 +396,15 @@ class SchemaTest < TinyTds::TestCase
         if @client.tds_73?
           assertions = lambda {
             assert_instance_of Time, v
-            assert_equal 1984, v.year,         'Year'
-            assert_equal 1, v.month,           'Month'
-            assert_equal 24, v.day,            'Day'
-            assert_equal 4, v.hour,            'Hour'
-            assert_equal 20, v.min,            'Minute'
-            assert_equal 59, v.sec,            'Second'
-            assert_equal 123456, v.usec,       'Microseconds'
-            assert_equal 123456700, v.nsec,    'Nanoseconds'
-            assert_equal -28800, v.utc_offset, 'Offset'
+            assert_equal 1984, v.year,           'Year'
+            assert_equal 1, v.month,             'Month'
+            assert_equal 24, v.day,              'Day'
+            assert_equal 4, v.hour,              'Hour'
+            assert_equal 20, v.min,              'Minute'
+            assert_equal 59, v.sec,              'Second'
+            assert_equal 123456, v.usec,         'Microseconds'
+            assert_equal 123456700, v.nsec,      'Nanoseconds'
+            assert_equal (-28800), v.utc_offset, 'Offset'
           }
           assertions.call
           v = find_value 84, :datetimeoffset_7, timezone: :local

--- a/test/thread_test.rb
+++ b/test/thread_test.rb
@@ -49,7 +49,7 @@ class ThreadTest < TinyTds::TestCase
             begin
               result = client.execute "select dbname()"
               result.each { |r| puts r }
-            rescue Exception => e
+            rescue Exception => _e
               # We are throwing an error on purpose here since 0.6.1 would
               # segfault on errors thrown in threads
             end


### PR DESCRIPTION
Fixing a few test warnings:

```
test/result_test.rb:687: warning: assigned but unused variable - result1
test/schema_test.rb:17: warning: ambiguous first argument; put parentheses or a space even after `-' operator
test/schema_test.rb:99: warning: ambiguous first argument; put parentheses or a space even after `-' operator
test/schema_test.rb:173: warning: ambiguous first argument; put parentheses or a space even after `-' operator
test/schema_test.rb:407: warning: ambiguous first argument; put parentheses or a space even after `-' operator
test/thread_test.rb:52: warning: assigned but unused variable - e
```