### PR TITLE
Raise error if client is unable to execute statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Improve handling of network related timeouts
 * Fix error reporting when preceded by info message
+* Raise error if client is unable to execute statement
 
 ## 2.1.3
 

--- a/ext/tiny_tds/client.c
+++ b/ext/tiny_tds/client.c
@@ -296,8 +296,8 @@ static VALUE rb_tinytds_execute(VALUE self, VALUE sql) {
   REQUIRE_OPEN_CLIENT(cwrap);
   dbcmd(cwrap->client, StringValueCStr(sql));
   if (dbsqlsend(cwrap->client) == FAIL) {
-    rb_warn("TinyTds: dbsqlsend() returned FAIL.\n");
-    return Qfalse;
+    rb_raise(cTinyTdsError, "failed to execute statement");
+    return self;
   }
   cwrap->userdata->dbsql_sent = 1;
   result = rb_tinytds_new_result_obj(cwrap);


### PR DESCRIPTION
`TinyTDS` returns `false` when you try to execute a query and for some reason it fails (dead connection, a network intermittent error, etc). This PR changes this behavior to raise an exception instead.

This is particular useful for ORMs built on top of TinyTDS connection like Sequel or ActiveRecord. Note that this also breaks the public API and this might be undesired.

Fixes #451.