### PR TITLE
AppVeyor - Fix freetds install errors by updating packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,16 @@ install:
   - perl --version
   - ruby --version
   - gem --version
-
+  # Update keyring according to https://www.msys2.org/news/#2020-06-29-new-packagers
+  - C:\msys64\usr\bin\curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
+  - C:\msys64\usr\bin\curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig
+  - ridk exec bash -c "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
+  - ridk exec bash -c "pacman -U --noconfirm --config <(echo) msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+  # update packages
+  - C:\msys64\usr\bin\pacman --noconfirm --ask 20 --sync --refresh --refresh --sysupgrade --sysupgrade
+  # Kill all running msys2 binaries to avoid error "size of shared memory region changed".
+  # See https://github.com/msys2/MSYS2-packages/issues/258
+  - powershell -Command "Get-Process | Where-Object {$_.path -like 'C:\msys64*'} | Stop-Process"
   # prevent freetds to link to wrong ws2_32 lib on i686-w64-mingw32
   - c:/msys64/usr/bin/rm /usr/lib/w32api/libws2_32.a
   # Set up project prerequisits


### PR DESCRIPTION
AppVeyor builds have been failing during `freetds` installation due to outdated packages:

```
warning: no /var/cache/pacman/pkg/ cache exists, creating...
error: failed retrieving file 'mingw-w64-i686-freetds-1.00.100-1-any.pkg.tar.xz' from repo.msys2.org : The requested URL returned error: 404
error: failed retrieving file 'mingw-w64-i686-freetds-1.00.100-1-any.pkg.tar.xz' from sourceforge.net : The requested URL returned error: 404
error: failed retrieving file 'mingw-w64-i686-freetds-1.00.100-1-any.pkg.tar.xz' from www2.futureware.at : The requested URL returned error: 404
error: failed retrieving file 'mingw-w64-i686-freetds-1.00.100-1-any.pkg.tar.xz' from mirror.yandex.ru : The requested URL returned error: 404
warning: failed to retrieve some files
error: failed to commit transaction (unexpected error)
```

Adds install commands to the `appveyor.yml` so that `freetds` installs successfully. 

I would expect running something similar to `pacman -Syu` would do the job, however, it appears there were recent changes to MSYS2 that require more setup. These commands were borrowed from https://github.com/oneclick/rubyinstaller2/blob/566169328a88c4960c75f0b25ef0c6fb5327fb46/appveyor.yml#L14-L31