### PR TITLE
Fix appveyor builds with pacman update workaround

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,9 @@ install:
   - C:\msys64\usr\bin\curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig
   - ridk exec bash -c "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
   - ridk exec bash -c "pacman -U --noconfirm --config <(echo) msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+  # Update zstd and pacman first https://github.com/msys2/MSYS2-packages/issues/2300
+  - C:\msys64\usr\bin\pacman -U https://repo.msys2.org/msys/x86_64/zstd-1.4.7-1-x86_64.pkg.tar.xz # Must come First, or else pacman will install 1.4.8
+  - C:\msys64\usr\bin\pacman -U https://repo.msys2.org/msys/x86_64/pacman-5.2.2-5-x86_64.pkg.tar.xz
   # update packages
   - C:\msys64\usr\bin\pacman --noconfirm --ask 20 --sync --refresh --refresh --sysupgrade --sysupgrade
   # Kill all running msys2 binaries to avoid error "size of shared memory region changed".

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,8 @@ install:
   - ridk exec bash -c "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
   - ridk exec bash -c "pacman -U --noconfirm --config <(echo) msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
   # Update zstd and pacman first https://github.com/msys2/MSYS2-packages/issues/2300
-  - C:\msys64\usr\bin\pacman -U https://repo.msys2.org/msys/x86_64/zstd-1.4.7-1-x86_64.pkg.tar.xz # Must come First, or else pacman will install 1.4.8
-  - C:\msys64\usr\bin\pacman -U https://repo.msys2.org/msys/x86_64/pacman-5.2.2-5-x86_64.pkg.tar.xz
+  - C:\msys64\usr\bin\pacman --noconfirm --upgrade https://repo.msys2.org/msys/x86_64/zstd-1.4.7-1-x86_64.pkg.tar.xz # Must come First, or else pacman will install 1.4.8
+  - C:\msys64\usr\bin\pacman --noconfirm --upgrade https://repo.msys2.org/msys/x86_64/pacman-5.2.2-5-x86_64.pkg.tar.xz
   # update packages
   - C:\msys64\usr\bin\pacman --noconfirm --ask 20 --sync --refresh --refresh --sysupgrade --sysupgrade
   # Kill all running msys2 binaries to avoid error "size of shared memory region changed".


### PR DESCRIPTION
Appveyor builds were failing when updating packages:

```
:: Proceed with installation? [Y/n] 
:: Retrieving packages...
downloading bash-5.1.004-1-x86_64.pkg.tar.zst...
downloading filesystem-2021.01-1-x86_64.pkg.tar.zst...
downloading mintty-1~3.4.4-1-x86_64.pkg.tar.zst...
downloading msys2-runtime-3.1.7-4-x86_64.pkg.tar.xz...
downloading msys2-runtime-devel-3.1.7-4-x86_64.pkg.tar.xz...
downloading pacman-mirrors-20201208-1-any.pkg.tar.xz...
downloading zstd-1.4.8-1-x86_64.pkg.tar.zst...
downloading pacman-5.2.2-9-x86_64.pkg.tar.zst...
checking keyring...
checking package integrity...
loading package files...
error: could not open file /var/cache/pacman/pkg/bash-5.1.004-1-x86_64.pkg.tar.zst: Child process exited with status 127
error: could not open file /var/cache/pacman/pkg/filesystem-2021.01-1-x86_64.pkg.tar.zst: Child process exited with status 127
error: could not open file /var/cache/pacman/pkg/mintty-1~3.4.4-1-x86_64.pkg.tar.zst: Child process exited with status 127
error: could not open file /var/cache/pacman/pkg/zstd-1.4.8-1-x86_64.pkg.tar.zst: Child process exited with status 127
error: could not open file /var/cache/pacman/pkg/pacman-5.2.2-9-x86_64.pkg.tar.zst: Child process exited with status 127
error: failed to commit transaction (cannot open package file)
Errors occurred, no packages were upgraded.
```

This issue https://github.com/msys2/MSYS2-packages/issues/2300 mentions the same problem and suggested a workaround by updating `zstd` and `pacman` first, before doing the full package update. Which seems to have done the trick.