### PR TITLE
Fix Appveyor builds by refreshing the package list

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,8 @@ install:
   # Kill all running msys2 binaries to avoid error "size of shared memory region changed".
   # See https://github.com/msys2/MSYS2-packages/issues/258
   - powershell -Command "Get-Process | Where-Object {$_.path -like 'C:\msys64*'} | Stop-Process"
+  # refresh the package list to avoid "error: failed to prepare transaction (could not find database)"
+  - ridk exec bash -c "pacman --noconfirm -Sy"
   # prevent freetds to link to wrong ws2_32 lib on i686-w64-mingw32
   - c:/msys64/usr/bin/rm /usr/lib/w32api/libws2_32.a
   # Set up project prerequisits


### PR DESCRIPTION
Appveyor builds were breaking due to an error related to pacman when running `bundle install`:

```
warning: database file for 'ucrt64' does not exist (use '-Sy' to download)
warning: database file for 'clang64' does not exist (use '-Sy' to download)
error: failed to prepare transaction (could not find database)
```

Running `pacman --noconfirm -Sy` to update the package list resolves this error and the builds pass successfully.
