### PR TITLE
Fix login timeout segmentation faults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## (unreleased)
 
 * Fix compilation errors for Amazon Linux 1. Fixes #495.
+* Fix segfault for login timeouts
 
 ## 2.1.4
 

--- a/ext/tiny_tds/client.c
+++ b/ext/tiny_tds/client.c
@@ -96,13 +96,14 @@ int tinytds_err_handler(DBPROCESS *dbproc, int severity, int dberr, int oserr, c
       but we don't ever want to automatically retry. Instead have the app
       decide what to do.
       */
-      if (userdata->timing_out) {
+      if (userdata && userdata->timing_out) {
         return INT_CANCEL;
       }
-      else {
+      // userdata will not be set if hitting timeout during login so check for it first
+      if (userdata) {
         userdata->timing_out = 1;
-        return_value = INT_TIMEOUT;
       }
+      return_value = INT_TIMEOUT;
       cancel = 1;
       break;
 

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -186,8 +186,8 @@ class ClientTest < TinyTds::TestCase
         end
         assert_raise_tinytds_error(action) do |e|
           assert_equal 20003, e.db_error_number
-            assert_equal 6, e.severity
-            assert_match %r{timed out}i, e.message, 'ignore if non-english test run'
+          assert_equal 6, e.severity
+          assert_match %r{timed out}i, e.message, 'ignore if non-english test run'
         end
       ensure
         assert_new_connections_work

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -176,7 +176,7 @@ class ClientTest < TinyTds::TestCase
       end
     end
 
-    it 'raises TinyTds exception with login timeout xxx' do
+    it 'raises TinyTds exception with login timeout' do
       skip if ENV['CI'] && ENV['APPVEYOR_BUILD_FOLDER'] # only CI using docker
       begin
         action = lambda do

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -176,6 +176,24 @@ class ClientTest < TinyTds::TestCase
       end
     end
 
+    it 'raises TinyTds exception with login timeout xxx' do
+      skip if ENV['CI'] && ENV['APPVEYOR_BUILD_FOLDER'] # only CI using docker
+      begin
+        action = lambda do
+          Toxiproxy[:sqlserver_test].toxic(:timeout, timeout: 0).apply do
+            new_connection login_timeout: 1, port: 1234
+          end
+        end
+        assert_raise_tinytds_error(action) do |e|
+          assert_equal 20003, e.db_error_number
+            assert_equal 6, e.severity
+            assert_match %r{timed out}i, e.message, 'ignore if non-english test run'
+        end
+      ensure
+        assert_new_connections_work
+      end
+    end
+
     it 'raises TinyTds exception with wrong :username' do
       skip if ENV['CI'] && sqlserver_azure? # Some issue with db_error_number.
       options = connection_options :username => 'willnotwork'


### PR DESCRIPTION
### Summary

Fixes a bug introduced in #481. When a login timeout occurs, `userdata` has not been initialized so it is a null pointer. Updating the timeout error handling to detect this so no segmentation fault occurs. Added a test to ensure login timeouts are working as expected. 