### PR TITLE
Update CI/Cross compile Ruby version support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,9 @@ env:
     - TESTOPTS="-v"
     - TINYTDS_UNIT_HOST=localhost
 rvm:
-  - 2.4.5
-  - 2.5.3
-  - 2.6.1
-  - 2.7.0
+  - 2.6.8
+  - 2.7.4
+  - 3.0.2
 before_install:
   - docker info
   - docker-compose up -d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## (unreleased)
 
+* Add Ruby 3.0 to the cross compile list
+* Removed EOL Rubies from CI & Cross compile list
+
 ## 2.1.5
 
 * Fix compilation errors for Amazon Linux 1. Fixes #495.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,10 +63,11 @@ environment:
   TINYTDS_UNIT_AZURE_PASS:
     secure: fYKSKV4v+36OFQp2nZdX4DfUpgmy5cm0wuR73cgdmEk=
   matrix:
-    - ruby_version: "24"
-    - ruby_version: "25-x64"
     - ruby_version: "26"
-    - ruby_version: "head-x64"
+    - ruby_version: "27"
+    - ruby_version: "27-x64"
+    - ruby_version: "30"
+    - ruby_version: "30-x64"
 on_failure:
   - find -name config.log | xargs cat
   - find -name compile.log | xargs cat

--- a/tasks/native_gem.rake
+++ b/tasks/native_gem.rake
@@ -8,7 +8,7 @@ task 'gem:windows' => ['ports:cross'] do
   build = ['bundle']
 
   # and finally build the native gem
-  build << 'rake cross native gem RUBY_CC_VERSION=2.7.0:2.6.0:2.5.0:2.4.0 CFLAGS="-Wall" MAKE="make -j`nproc`"'
+  build << 'rake cross native gem RUBY_CC_VERSION=3.0.0:2.7.0:2.6.0 CFLAGS="-Wall" MAKE="make -j`nproc`"'
 
   RakeCompilerDock.sh build.join(' && ')
 end


### PR DESCRIPTION
Add Ruby 3.0 to CI and cross compile list. This also drops any rubies
below 2.6 from CI and cross compile since they are now EOL. This is
based on the changes in #456 to add Ruby 2.7

Closes: #503