### PR TITLE
Fix dangling pointer after client.close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## (unreleased)
 
 * Add Ruby 3.0 to the cross compile list
+* Fix segfault when asking if client was dead after closing it. Fixes #519.
 
 ## 2.1.5
 

--- a/ext/tiny_tds/client.c
+++ b/ext/tiny_tds/client.c
@@ -232,6 +232,7 @@ static void rb_tinytds_client_free(void *ptr) {
     dbloginfree(cwrap->login);
   if (cwrap->client && !cwrap->closed) {
     dbclose(cwrap->client);
+    cwrap->client = NULL;
     cwrap->closed = 1;
     cwrap->userdata->closed = 1;
   }
@@ -263,6 +264,7 @@ static VALUE rb_tinytds_close(VALUE self) {
   GET_CLIENT_WRAPPER(self);
   if (cwrap->client && !cwrap->closed) {
     dbclose(cwrap->client);
+    cwrap->client = NULL;
     cwrap->closed = 1;
     cwrap->userdata->closed = 1;
   }

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -16,6 +16,7 @@ class ClientTest < TinyTds::TestCase
       assert @client.close
       assert @client.closed?
       assert !@client.active?
+      assert @client.dead?
       action = lambda { @client.execute('SELECT 1 as [one]').each }
       assert_raise_tinytds_error(action) do |e|
         assert_match %r{closed connection}i, e.message, 'ignore if non-english test run'


### PR DESCRIPTION
### Context

Hey there!

Firstly, I want to express my appreciation for the hard work and dedication that you have put into maintaining this project. Your efforts have been incredibly valuable to me and many others in the community.

Well, as reported in the issue #519, we ran into an unexpected Segmentation Fault Error while verifying whether a client was dead after closing it. Upon investigation, we discovered (following the [leads](https://github.com/rails-sqlserver/tiny_tds/issues/519#issuecomment-1222718722) of @aharpervc ) that the root cause of the issue was that by calling `dbclose`, we were [deallocating memory used by the client structure without setting the pointer to NULL](https://github.com/FreeTDS/freetds/blob/0a87ec6faf26c187ed58fb52ddf070b445bfbec9/src/dblib/dblib.c#L1541) after closing the client connection. 
This led to a dangling pointer, which ultimately resulted in the Segmentation Fault error when we tried to check whether the client was dead using TDS `dbdead` ([here](https://github.com/FreeTDS/freetds/blob/0a87ec6faf26c187ed58fb52ddf070b445bfbec9/src/dblib/dblib.c#L5063-L5074)).

To prevent this issue from happening again, I've made the necessary updates to ensure that the client pointer is set to NULL after every `dbclose`. This fix will help us avoid any dangling pointers and keep our code running smoothly.

I also tested this locally both before and after building the gem with the changes and everything is working like a charm now! 

```ruby
client = TinyTds::Client.new(**ops)
client.close
client.dead? # --> True
```

I wanted to note that while another solution would have checked whether the client was closed (`cwrap->closed`) before calling `dbdead`, I didn't feel comfortable leaving any dangling pointers. 😅

Let me know if you have any questions or concerns.

### Changelog

- Considered testing `client.dead?` after closing the connection in the Client test cases.
- Fixed dangling pointers after calling `dbclose`.