### PR TITLE
Add Ruby 3.0 to the cross compile list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,5 +274,6 @@ workflows:
                 - '2.5'
                 - '2.6'
                 - '2.7'
+                - '3.0'
       - test_linux:
           matrix: *ruby_versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## (unreleased)
 
+* Add Ruby 3.0 to the cross compile list
+
 ## 2.1.5
 
 * Fix compilation errors for Amazon Linux 1. Fixes #495.

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ GEM_PLATFORM_HOSTS = {
   'x86-mingw32' => 'i686-w64-mingw32',
   'x64-mingw32' => 'x86_64-w64-mingw32'
 }
-RUBY_CC_VERSION="2.7.0:2.6.0:2.5.0:2.4.0".freeze
+RUBY_CC_VERSION="3.0.0:2.7.0:2.6.0:2.5.0:2.4.0".freeze
 
 # Add our project specific files to clean for a rebuild
 CLEAN.include FileList["{ext,lib}/**/*.{so,#{RbConfig::CONFIG['DLEXT']},o}"],


### PR DESCRIPTION
Replaces #524 

This PR adds Ruby 3.0 to the cross-compile list. With #525, few things related to the CI changed and couple of changes like the OpenSSL update have been implemented with #525 as well. So opening a new PR was simpler than overwriting the existing one.