### PR TITLE
Look for freetds in /opt/homebrew

### DIFF
--- a/ext/tiny_tds/extconf.rb
+++ b/ext/tiny_tds/extconf.rb
@@ -30,6 +30,7 @@ freetds_ports_dir = File.expand_path(freetds_ports_dir)
 # order is important here! First in, first searched.
 DIRS = %w(
   /opt/local
+  /opt/homebrew
   /usr/local
 )
 


### PR DESCRIPTION
Homebrew recently changed the directory it installs into from /usr/local to /opt/homebrew. This change allows users to install tiny_tds on macOS.