### PR TITLE
 On Windows add the msys path where freetds is automatically installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add Ruby 3.0 to the cross compile list
 * Fix segfault when asking if client was dead after closing it. Fixes #519.
+* Fix Gem installation on Windows by adding default freetds msys path. Fixes #522
 
 ## 2.1.5
 

--- a/ext/tiny_tds/extconf.rb
+++ b/ext/tiny_tds/extconf.rb
@@ -33,6 +33,10 @@ DIRS = %w(
   /usr/local
 )
 
+if ENV["RI_DEVKIT"] && ENV["MINGW_PREFIX"] # RubyInstaller Support
+  DIRS.unshift(File.join(ENV["RI_DEVKIT"], ENV["MINGW_PREFIX"]))
+end
+
 # Add the ports directory if it exists for local developer builds
 DIRS.unshift(freetds_ports_dir) if File.directory?(freetds_ports_dir)
 


### PR DESCRIPTION
 (C:/Ruby32-x64/msys64/ucrt64/include/freetds)


This should fix the issue where users on windows can't just run gem install tiny_tds 
