### PR TITLE
Fix path to artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,19 @@ jobs:
       - store_test_results:
           path: test/reports
 
+      - run:
+          name: Rename gem to a consistent name to store artifact
+          command: |
+            $Env:PATH = "C:\\Ruby<< parameters.ruby_version >>-x64\\bin;$Env:PATH"
+            $rubyArchitecture = (ruby -e 'puts RUBY_PLATFORM').Trim()
+            $gemVersion = (Get-Content VERSION).Trim()
+
+            New-Item -Path . -Name "tested_artifact" -ItemType "directory"
+            Move-Item "artifacts/gems/tiny_tds-$gemVersion-$rubyArchitecture.gem" "tested_artifact"
+
+      - store_artifacts:
+          path: tested_artifact
+
   cross_compile_gem:
     parameters:
       platform:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,7 +259,7 @@ jobs:
             rm -rf artifacts-<< parameters.platform >>/gems/tiny_tds-$gemVersion.gem
 
       - store_artifacts:
-          path: artifacts/gems
+          path: artifacts-<< parameters.platform >>/gems
 
       - save_cache:
           name: save ports cache


### PR DESCRIPTION
As I parallelized the cross-compilation process, the gems were moved into another folder dedicated to their target platform during the build. This change was not reflected when storing the artifacts.