### PR TITLE
Mark `alloc` as undefined for `TinyTds::Result`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add Ruby 3.0 to the cross compile list
 * Fix segfault when asking if client was dead after closing it. Fixes #519.
+* Mark `alloc` function as undefined on `TinyTds::Result`. Fixes #515.
 
 ## 2.1.5
 

--- a/ext/tiny_tds/result.c
+++ b/ext/tiny_tds/result.c
@@ -584,6 +584,7 @@ void init_tinytds_result() {
   cDate = rb_const_get(rb_cObject, rb_intern("Date"));
   /* Define TinyTds::Result */
   cTinyTdsResult = rb_define_class_under(mTinyTds, "Result", rb_cObject);
+  rb_undef_alloc_func(cTinyTdsResult);
   /* Define TinyTds::Result Public Methods */
   rb_define_method(cTinyTdsResult, "fields", rb_tinytds_result_fields, 0);
   rb_define_method(cTinyTdsResult, "each", rb_tinytds_result_each, -1);


### PR DESCRIPTION
From my understanding, you only need to define an `alloc` function if you want to define a C struct and store values on it. For example, `TinyTds::Client` defines such an `allocate` function to wrap its client. On `TinyTds::Result`, it does not seem we do have a struct and therefore does not need an `alloc` function.

Closes #515 