### PR TITLE
Do not remove Ruby setup file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,6 @@ jobs:
             ruby --version
             echo "Gem Version:"
             gem --version
-            rm .\ruby-setup.exe
 
       - run:
           name: install bundler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,10 +117,10 @@ jobs:
             echo "Ruby Target Version Found: $target_version"
 
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-            Invoke-WebRequest -UseBasicParsing -uri $download_uri -OutFile ruby-setup.exe
-            
+            Invoke-WebRequest -UseBasicParsing -uri $download_uri -OutFile C:\ruby-setup.exe
+
             echo "Download finished, starting installation of $target_version"
-            .\ruby-setup.exe /VERYSILENT /NORESTART /ALLUSERS /DIR=C:/Ruby<< parameters.ruby_version >>-x64
+            C:\ruby-setup.exe /VERYSILENT /NORESTART /ALLUSERS /DIR=C:/Ruby<< parameters.ruby_version >>-x64
 
       - run:
           name: ruby diagnostics


### PR DESCRIPTION
I observed that sometimes, CircleCI hangs for a solid 10 minutes on the "Ruby diagnostic" step. Perl, Ruby and Gem version are already visible, so I assume that the delete operation takes very long sometimes.

I do no think we need to throw away the setup file ourselves, as we get fresh VMs with each run anyhow. However, CircleCI does not like if the current directory, where you want to check out the code, is not empty. Downloading the setup file to C: should fix that issue.
