### PR TITLE
Drop support for Ruby < 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,9 +385,6 @@ workflows:
           matrix: &ruby_versions
             parameters:
               ruby_version:
-                - '2.4'
-                - '2.5'
-                - '2.6'
                 - '2.7'
                 - '3.0'
                 - '3.1'
@@ -397,13 +394,4 @@ workflows:
           matrix: *ruby_versions
 
       - install_windows:
-          matrix:
-            parameters:
-              ruby_version:
-                - '2.5'
-                - '2.6'
-                - '2.7'
-                - '3.0'
-                - '3.1'
-                - '3.2'
-                - '3.3'
+          matrix: *ruby_versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## (unreleased)
+
+* Drop support for Ruby < 2.7
+
 ## 2.1.7
 * Add Ruby 3.3 to the cross compile list
 

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ require_relative './ext/tiny_tds/extconsts'
 SPEC = Gem::Specification.load(File.expand_path('../tiny_tds.gemspec', __FILE__))
 
 ruby_cc_ucrt_versions = "3.3.0:3.2.0:3.1.0".freeze
-ruby_cc_mingw32_versions = "3.0.0:2.7.0:2.6.0:2.5.0:2.4.0".freeze
+ruby_cc_mingw32_versions = "3.0.0:2.7.0".freeze
 
 GEM_PLATFORM_HOSTS = {
   'x86-mingw32' => {

--- a/tiny_tds.gemspec
+++ b/tiny_tds.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.rdoc_options  = ['--charset=UTF-8']
   s.extensions    = ['ext/tiny_tds/extconf.rb']
   s.license       = 'MIT'
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.7.0'
   s.metadata['msys2_mingw_dependencies'] = 'freetds'
   s.add_development_dependency 'mini_portile2', '~> 2.5.0'
   s.add_development_dependency 'rake', '~> 13.0.0'


### PR DESCRIPTION
I assume the `activerecord-sql-adapter` is the source of most of our Gem installations. Rails 7.0 requires Ruby 2.7 at minimum. I think this a good base line for now. It would still allow people with older Rubys to upgrade to the eventual v3.0 release, but we do no longer support ancient Ruby versions (like 2.4).

Related to #552.