### PR TITLE
Raise error if dbsqlsend fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Drop support for Ruby < 2.7
 * Drop support for SQL Server < 2017
 * Drop support for FreeTDS < 1.0
+* Raise error if FreeTDS is unable to sent command buffer to the server
 
 ## 2.1.7
 * Add Ruby 3.3 to the cross compile list

--- a/ext/tiny_tds/client.c
+++ b/ext/tiny_tds/client.c
@@ -299,8 +299,7 @@ static VALUE rb_tinytds_execute(VALUE self, VALUE sql) {
   REQUIRE_OPEN_CLIENT(cwrap);
   dbcmd(cwrap->client, StringValueCStr(sql));
   if (dbsqlsend(cwrap->client) == FAIL) {
-    rb_warn("TinyTds: dbsqlsend() returned FAIL.\n");
-    return Qfalse;
+    rb_raise(cTinyTdsError, "failed dbsqlsend() function");
   }
   cwrap->userdata->dbsql_sent = 1;
   result = rb_tinytds_new_result_obj(cwrap);


### PR DESCRIPTION
Closes #464
Relates to #552

With this PR, `tiny_tds` will raise an error in case `dbsqlsend` will return `FAIL` instead of returning false. It is essentially the code from #469 / @wpolicarpo.

I spent an evening trying to build a test that would yield this error. I came up with a solution that worked on my machine, but only sometimes on CI.

```ruby
it 'raises error when query cannot be sent' do
  client = new_connection
  assert_client_works(client)

  thread1 = Thread.new do
    client.execute("SELECT 1 as [one]").do
  end

  thread2 = Thread.new do
    assert_equal false, client.execute("SELECT 1 as [one]")
  end

  thread1.join
  thread2.join
end
```

I assume, when the result are read in thread1 and Ruby decides to switch to thread2, our FreeTDS wrapper is in an invalid state, which can trigger the issue. Likely, because they both try to access the DBPROCESS object, which [should not be allowed](https://www.freetds.org/faq.html#thread.safe).

I also tried various suggestions to kill the session or just restart the database server, none of them worked for me to trigger the error. I personally think we can still get this code in even if it has no tests, as it can avoid getting into weird state with tiny_tds.