### PR TITLE
Add `bigdecimal` as a dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           $gemToInstall = "./tiny_tds-$gemVersion-$rubyArchitecture.gem"
 
           Write-Host "Looking to install $gemToInstall"
-          gem install --local "$gemToInstall"
+          gem install "$gemToInstall"
 
       - name: Test if TinyTDS loads
         shell: pwsh
@@ -203,7 +203,7 @@ jobs:
           $gemToInstall = "./tiny_tds-$gemVersion-$rubyArchitecture.gem"
 
           Write-Host "Looking to install $gemToInstall"
-          gem install --local "$gemToInstall"
+          gem install "$gemToInstall"
 
       - name: Test if TinyTDS loads
         shell: pwsh
@@ -319,7 +319,7 @@ jobs:
         shell: pwsh
         run: |
           $gemVersion = (Get-Content VERSION).Trim()
-          gem install --local "tiny_tds-$gemVersion.gem"
+          gem install "tiny_tds-$gemVersion.gem"
 
       - name: Test if TinyTDS loads
         shell: pwsh
@@ -458,7 +458,7 @@ jobs:
         shell: bash
         run: |
           gemVersion=$(<VERSION tr -d '[:space:]')
-          gem install --local "tiny_tds-$gemVersion.gem"
+          gem install "tiny_tds-$gemVersion.gem"
 
       - name: Test if TinyTDS loads
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,18 +124,18 @@ jobs:
         run: |
           $rubyArchitecture = (ruby -e "puts RbConfig::CONFIG['arch']").Trim()
           $gemVersion = (Get-Content VERSION).Trim()
-          $gemToInstall = "./tiny_tds-$gemVersion-$rubyArchitecture.gem"
+          $gemToUnpack = "./tiny_tds-$gemVersion-$rubyArchitecture.gem"
 
-          Write-Host "Looking to install $gemToInstall"
-          gem install --local --install-dir=./tmp "$gemToInstall"
+          Write-Host "Looking to unpack $gemToUnpack"
+          gem unpack --target ./tmp "$gemToUnpack"
 
           # Restore precompiled code
-          $source = (Resolve-Path ".\tmp\gems\tiny_tds-$gemVersion-$rubyArchitecture\lib\tiny_tds").Path
+          $source = (Resolve-Path ".\tmp\tiny_tds-$gemVersion-$rubyArchitecture\lib\tiny_tds").Path
           $destination = (Resolve-Path ".\lib\tiny_tds").Path
           Get-ChildItem $source -Recurse -Exclude "*.rb" | Copy-Item -Destination {Join-Path $destination $_.FullName.Substring($source.length)}
 
           # Restore ports
-          Copy-Item -Path ".\tmp\gems\tiny_tds-$gemVersion-$rubyArchitecture\ports" -Destination "." -Recurse
+          Copy-Item -Path ".\tmp\tiny_tds-$gemVersion-$rubyArchitecture\ports" -Destination "." -Recurse
 
       - name: Setup MSSQL
         uses: potatoqualitee/mssqlsuite@v1.7
@@ -245,18 +245,18 @@ jobs:
         run: |
           $rubyArchitecture = (ruby -e "puts RbConfig::CONFIG['arch']").Trim()
           $gemVersion = (Get-Content VERSION).Trim()
-          $gemToInstall = "./tiny_tds-$gemVersion-$rubyArchitecture.gem"
+          $gemToUnpack = "./tiny_tds-$gemVersion-$rubyArchitecture.gem"
 
-          Write-Host "Looking to install $gemToInstall"
-          gem install --local --install-dir=./tmp "$gemToInstall"
+          Write-Host "Looking to unpack $gemToUnpack"
+          gem unpack --target ./tmp "$gemToUnpack"
 
           # Restore precompiled code
-          $source = (Resolve-Path ".\tmp\gems\tiny_tds-$gemVersion-$rubyArchitecture\lib\tiny_tds").Path
+          $source = (Resolve-Path ".\tmp\tiny_tds-$gemVersion-$rubyArchitecture\lib\tiny_tds").Path
           $destination = (Resolve-Path ".\lib\tiny_tds").Path
           Get-ChildItem $source -Recurse -Exclude "*.rb" | Copy-Item -Destination {Join-Path $destination $_.FullName.Substring($source.length)}
 
           # Restore ports
-          Copy-Item -Path ".\tmp\gems\tiny_tds-$gemVersion-$rubyArchitecture\ports" -Destination "." -Recurse
+          Copy-Item -Path ".\tmp\tiny_tds-$gemVersion-$rubyArchitecture\ports" -Destination "." -Recurse
 
       - name: Setup MSSQL
         uses: potatoqualitee/mssqlsuite@v1.7

--- a/tiny_tds.gemspec
+++ b/tiny_tds.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
   s.required_ruby_version = '>= 2.7.0'
   s.metadata['msys2_mingw_dependencies'] = 'freetds'
+  s.add_dependency 'bigdecimal', '~> 3'
   s.add_development_dependency 'mini_portile2', '~> 2.5.0'
   s.add_development_dependency 'rake', '~> 13.0.0'
   s.add_development_dependency 'rake-compiler', '~> 1.2'


### PR DESCRIPTION
This is to address the following warning on Ruby 3.3:

```
/home/apf/dev/rails-sqlserver/tiny_tds/lib/tiny_tds.rb:3: warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec.
```