### PR TITLE
Format `C` code with Artistic Style

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,8 +555,8 @@ jobs:
         run: |
           ruby -e "require 'tiny_tds'; puts TinyTds::Gem.root_path"
 
-  standardrb:
-    name: standardrb
+  formatting:
+    name: Code formatting
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -569,3 +569,12 @@ jobs:
       - name: Check standardrb
         shell: bash
         run: bundle exec standardrb
+
+      - name: Check artistic style
+        uses: per1234/artistic-style-action@v1
+        with:
+          options-file-path: "astyle.conf"
+          target-paths: "./ext/"
+          name-patterns: |
+            - '*.c'
+            - '*.h'

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ $ rake TINYTDS_UNIT_HOST=mydb.host.net TINYTDS_SCHEMA=sqlserver_azure
 
 ### Code formatting
 
-We are using `standardrb` to format our code. Just run `bundle exec standardrb --fix` to format all Ruby files.
+We are using `standardrb` to format the Ruby code and Artistic Style for the C code. Run `bundle exec rake format` to format both types in one operation. Artistic Style needs to be manually installed through your package manager (e.g. `apt install -y astyle`).
 
 ### Compiling Gems for Windows and Linux
 

--- a/Rakefile
+++ b/Rakefile
@@ -65,3 +65,8 @@ end
 
 task build: [:clean, :compile]
 task default: [:build, :test]
+
+task :format do
+  system("bundle exec standardrb --fix")
+  system('astyle --options=astyle.conf "./ext/*.c" "./ext/*.h"')
+end

--- a/astyle.conf
+++ b/astyle.conf
@@ -1,0 +1,8 @@
+--style=1tbs
+--break-blocks
+--indent-preproc-block
+--indent-preproc-cond
+--indent=spaces=2
+--indent-switches
+--recursive
+--suffix=none

--- a/ext/tiny_tds/client.c
+++ b/ext/tiny_tds/client.c
@@ -24,26 +24,36 @@ VALUE opt_escape_regex, opt_escape_dblquote;
 
 // Lib Backend (Helpers)
 
-VALUE rb_tinytds_raise_error(DBPROCESS *dbproc, tinytds_errordata error) {
+VALUE rb_tinytds_raise_error(DBPROCESS *dbproc, tinytds_errordata error)
+{
   VALUE e;
   GET_CLIENT_USERDATA(dbproc);
+
   if (error.cancel && !dbdead(dbproc) && userdata && !userdata->closed) {
     userdata->dbsqlok_sent = 1;
     dbsqlok(dbproc);
     userdata->dbcancel_sent = 1;
     dbcancel(dbproc);
   }
+
   e = rb_exc_new2(cTinyTdsError, error.error);
   rb_funcall(e, intern_source_eql, 1, rb_str_new2(error.source));
-  if (error.severity)
+
+  if (error.severity) {
     rb_funcall(e, intern_severity_eql, 1, INT2FIX(error.severity));
-  if (error.dberr)
+  }
+
+  if (error.dberr) {
     rb_funcall(e, intern_db_error_number_eql, 1, INT2FIX(error.dberr));
-  if (error.oserr)
+  }
+
+  if (error.oserr) {
     rb_funcall(e, intern_os_error_number_eql, 1, INT2FIX(error.oserr));
+  }
 
   if (error.severity <= 10 && error.is_message) {
     VALUE message_handler = userdata && userdata->message_handler ? userdata->message_handler : Qnil;
+
     if (message_handler && message_handler != Qnil && rb_respond_to(message_handler, intern_call) != 0) {
       rb_funcall(message_handler, intern_call, 1, e);
     }
@@ -57,7 +67,8 @@ VALUE rb_tinytds_raise_error(DBPROCESS *dbproc, tinytds_errordata error) {
 
 
 // Lib Backend (Memory Management & Handlers)
-static void push_userdata_error(tinytds_client_userdata *userdata, tinytds_errordata error) {
+static void push_userdata_error(tinytds_client_userdata *userdata, tinytds_errordata error)
+{
   // reallocate memory for the array as needed
   if (userdata->nonblocking_errors_size == userdata->nonblocking_errors_length) {
     userdata->nonblocking_errors_size *= 2;
@@ -68,7 +79,8 @@ static void push_userdata_error(tinytds_client_userdata *userdata, tinytds_error
   userdata->nonblocking_errors_length++;
 }
 
-int tinytds_err_handler(DBPROCESS *dbproc, int severity, int dberr, int oserr, char *dberrstr, char *oserrstr) {
+int tinytds_err_handler(DBPROCESS *dbproc, int severity, int dberr, int oserr, char *dberrstr, char *oserrstr)
+{
   static const char *source = "error";
   /* Everything should cancel by default */
   int return_value = INT_CANCEL;
@@ -91,6 +103,7 @@ int tinytds_err_handler(DBPROCESS *dbproc, int severity, int dberr, int oserr, c
       return return_value;
 
     case SYBETIME:
+
       /*
       SYBETIME is the only error that can send INT_TIMEOUT or INT_CONTINUE,
       but we don't ever want to automatically retry. Instead have the app
@@ -99,19 +112,23 @@ int tinytds_err_handler(DBPROCESS *dbproc, int severity, int dberr, int oserr, c
       if (userdata && userdata->timing_out) {
         return INT_CANCEL;
       }
+
       // userdata will not be set if hitting timeout during login so check for it first
       if (userdata) {
         userdata->timing_out = 1;
       }
+
       return_value = INT_TIMEOUT;
       cancel = 1;
       break;
 
     case SYBEWRIT:
+
       /* Write errors may happen after we abort a statement */
       if (userdata && (userdata->dbsqlok_sent || userdata->dbcancel_sent)) {
         return return_value;
       }
+
       cancel = 1;
       break;
   }
@@ -137,6 +154,7 @@ int tinytds_err_handler(DBPROCESS *dbproc, int severity, int dberr, int oserr, c
       dbcancel(dbproc);
       userdata->dbcancel_sent = 1;
     }
+
     push_userdata_error(userdata, error_data);
   } else {
     rb_tinytds_raise_error(dbproc, error_data);
@@ -145,7 +163,8 @@ int tinytds_err_handler(DBPROCESS *dbproc, int severity, int dberr, int oserr, c
   return return_value;
 }
 
-int tinytds_msg_handler(DBPROCESS *dbproc, DBINT msgno, int msgstate, int severity, char *msgtext, char *srvname, char *procname, int line) {
+int tinytds_msg_handler(DBPROCESS *dbproc, DBINT msgno, int msgstate, int severity, char *msgtext, char *srvname, char *procname, int line)
+{
   static const char *source = "message";
   GET_CLIENT_USERDATA(dbproc);
 
@@ -177,6 +196,7 @@ int tinytds_msg_handler(DBPROCESS *dbproc, DBINT msgno, int msgstate, int severi
   } else {
     rb_tinytds_raise_error(dbproc, error_data);
   }
+
   return 0;
 }
 
@@ -187,7 +207,8 @@ Right now, we only care about cases where a read from the server is
 taking longer than the specified timeout and dbcancel is not working.
 In these cases we decide that we actually want to handle the interrupt
 */
-static int check_interrupt(void *ptr) {
+static int check_interrupt(void *ptr)
+{
   GET_CLIENT_USERDATA((DBPROCESS *)ptr);
   return userdata->timing_out;
 }
@@ -199,15 +220,19 @@ Right now, this is only used in cases where a read from the server is
 taking longer than the specified timeout and dbcancel is not working.
 Return INT_CANCEL to abort the current command batch.
 */
-static int handle_interrupt(void *ptr) {
+static int handle_interrupt(void *ptr)
+{
   GET_CLIENT_USERDATA((DBPROCESS *)ptr);
+
   if (userdata->timing_out) {
     return INT_CANCEL;
   }
+
   return INT_CONTINUE;
 }
 
-static void rb_tinytds_client_reset_userdata(tinytds_client_userdata *userdata) {
+static void rb_tinytds_client_reset_userdata(tinytds_client_userdata *userdata)
+{
   userdata->timing_out = 0;
   userdata->dbsql_sent = 0;
   userdata->dbsqlok_sent = 0;
@@ -219,28 +244,36 @@ static void rb_tinytds_client_reset_userdata(tinytds_client_userdata *userdata) 
   userdata->nonblocking_errors_size = 0;
 }
 
-static void rb_tinytds_client_mark(void *ptr) {
+static void rb_tinytds_client_mark(void *ptr)
+{
   tinytds_client_wrapper *cwrap = (tinytds_client_wrapper *)ptr;
+
   if (cwrap) {
     rb_gc_mark(cwrap->charset);
   }
 }
 
-static void rb_tinytds_client_free(void *ptr) {
+static void rb_tinytds_client_free(void *ptr)
+{
   tinytds_client_wrapper *cwrap = (tinytds_client_wrapper *)ptr;
-  if (cwrap->login)
+
+  if (cwrap->login) {
     dbloginfree(cwrap->login);
+  }
+
   if (cwrap->client && !cwrap->closed) {
     dbclose(cwrap->client);
     cwrap->client = NULL;
     cwrap->closed = 1;
     cwrap->userdata->closed = 1;
   }
+
   xfree(cwrap->userdata);
   xfree(ptr);
 }
 
-static VALUE allocate(VALUE klass) {
+static VALUE allocate(VALUE klass)
+{
   VALUE obj;
   tinytds_client_wrapper *cwrap;
   obj = Data_Make_Struct(klass, tinytds_client_wrapper, rb_tinytds_client_mark, rb_tinytds_client_free, cwrap);
@@ -255,52 +288,63 @@ static VALUE allocate(VALUE klass) {
 
 // TinyTds::Client (public)
 
-static VALUE rb_tinytds_tds_version(VALUE self) {
+static VALUE rb_tinytds_tds_version(VALUE self)
+{
   GET_CLIENT_WRAPPER(self);
   return INT2FIX(dbtds(cwrap->client));
 }
 
-static VALUE rb_tinytds_close(VALUE self) {
+static VALUE rb_tinytds_close(VALUE self)
+{
   GET_CLIENT_WRAPPER(self);
+
   if (cwrap->client && !cwrap->closed) {
     dbclose(cwrap->client);
     cwrap->client = NULL;
     cwrap->closed = 1;
     cwrap->userdata->closed = 1;
   }
+
   return Qtrue;
 }
 
-static VALUE rb_tinytds_dead(VALUE self) {
+static VALUE rb_tinytds_dead(VALUE self)
+{
   GET_CLIENT_WRAPPER(self);
   return dbdead(cwrap->client) ? Qtrue : Qfalse;
 }
 
-static VALUE rb_tinytds_closed(VALUE self) {
+static VALUE rb_tinytds_closed(VALUE self)
+{
   GET_CLIENT_WRAPPER(self);
   return (cwrap->closed || cwrap->userdata->closed) ? Qtrue : Qfalse;
 }
 
-static VALUE rb_tinytds_canceled(VALUE self) {
+static VALUE rb_tinytds_canceled(VALUE self)
+{
   GET_CLIENT_WRAPPER(self);
   return cwrap->userdata->dbcancel_sent ? Qtrue : Qfalse;
 }
 
-static VALUE rb_tinytds_sqlsent(VALUE self) {
+static VALUE rb_tinytds_sqlsent(VALUE self)
+{
   GET_CLIENT_WRAPPER(self);
   return cwrap->userdata->dbsql_sent ? Qtrue : Qfalse;
 }
 
-static VALUE rb_tinytds_execute(VALUE self, VALUE sql) {
+static VALUE rb_tinytds_execute(VALUE self, VALUE sql)
+{
   VALUE result;
 
   GET_CLIENT_WRAPPER(self);
   rb_tinytds_client_reset_userdata(cwrap->userdata);
   REQUIRE_OPEN_CLIENT(cwrap);
   dbcmd(cwrap->client, StringValueCStr(sql));
+
   if (dbsqlsend(cwrap->client) == FAIL) {
     rb_raise(cTinyTdsError, "failed dbsqlsend() function");
   }
+
   cwrap->userdata->dbsql_sent = 1;
   result = rb_tinytds_new_result_obj(cwrap);
   rb_iv_set(result, "@query_options", rb_funcall(rb_iv_get(self, "@query_options"), intern_dup, 0));
@@ -312,17 +356,20 @@ static VALUE rb_tinytds_execute(VALUE self, VALUE sql) {
   }
 }
 
-static VALUE rb_tinytds_charset(VALUE self) {
+static VALUE rb_tinytds_charset(VALUE self)
+{
   GET_CLIENT_WRAPPER(self);
   return cwrap->charset;
 }
 
-static VALUE rb_tinytds_encoding(VALUE self) {
+static VALUE rb_tinytds_encoding(VALUE self)
+{
   GET_CLIENT_WRAPPER(self);
   return rb_enc_from_encoding(cwrap->encoding);
 }
 
-static VALUE rb_tinytds_escape(VALUE self, VALUE string) {
+static VALUE rb_tinytds_escape(VALUE self, VALUE string)
+{
   VALUE new_string;
   GET_CLIENT_WRAPPER(self);
 
@@ -333,8 +380,10 @@ static VALUE rb_tinytds_escape(VALUE self, VALUE string) {
 }
 
 /* Duplicated in result.c */
-static VALUE rb_tinytds_return_code(VALUE self) {
+static VALUE rb_tinytds_return_code(VALUE self)
+{
   GET_CLIENT_WRAPPER(self);
+
   if (cwrap->client && dbhasretstat(cwrap->client)) {
     return LONG2NUM((long)dbretstatus(cwrap->client));
   } else {
@@ -342,7 +391,8 @@ static VALUE rb_tinytds_return_code(VALUE self) {
   }
 }
 
-static VALUE rb_tinytds_identity_sql(VALUE self) {
+static VALUE rb_tinytds_identity_sql(VALUE self)
+{
   GET_CLIENT_WRAPPER(self);
   return rb_str_new2(cwrap->identity_insert_sql);
 }
@@ -351,7 +401,8 @@ static VALUE rb_tinytds_identity_sql(VALUE self) {
 
 // TinyTds::Client (protected)
 
-static VALUE rb_tinytds_connect(VALUE self, VALUE opts) {
+static VALUE rb_tinytds_connect(VALUE self, VALUE opts)
+{
   /* Parsing options hash to local vars. */
   VALUE user, pass, dataserver, database, app, version, ltimeout, timeout, charset, azure, contained, use_utf16;
   GET_CLIENT_WRAPPER(self);
@@ -369,44 +420,69 @@ static VALUE rb_tinytds_connect(VALUE self, VALUE opts) {
   contained = rb_hash_aref(opts, sym_contained);
   use_utf16 = rb_hash_aref(opts, sym_use_utf16);
   cwrap->userdata->message_handler = rb_hash_aref(opts, sym_message_handler);
+
   /* Dealing with options. */
   if (dbinit() == FAIL) {
     rb_raise(cTinyTdsError, "failed dbinit() function");
     return self;
   }
+
   dberrhandle(tinytds_err_handler);
   dbmsghandle(tinytds_msg_handler);
   cwrap->login = dblogin();
-  if (!NIL_P(version))
+
+  if (!NIL_P(version)) {
     dbsetlversion(cwrap->login, NUM2INT(version));
-  if (!NIL_P(user))
+  }
+
+  if (!NIL_P(user)) {
     dbsetluser(cwrap->login, StringValueCStr(user));
-  if (!NIL_P(pass))
+  }
+
+  if (!NIL_P(pass)) {
     dbsetlpwd(cwrap->login, StringValueCStr(pass));
-  if (!NIL_P(app))
+  }
+
+  if (!NIL_P(app)) {
     dbsetlapp(cwrap->login, StringValueCStr(app));
-  if (!NIL_P(ltimeout))
+  }
+
+  if (!NIL_P(ltimeout)) {
     dbsetlogintime(NUM2INT(ltimeout));
-  if (!NIL_P(charset))
+  }
+
+  if (!NIL_P(charset)) {
     DBSETLCHARSET(cwrap->login, StringValueCStr(charset));
+  }
+
   if (!NIL_P(database)) {
     if (azure == Qtrue || contained == Qtrue) {
       #ifdef DBSETLDBNAME
-        DBSETLDBNAME(cwrap->login, StringValueCStr(database));
+      DBSETLDBNAME(cwrap->login, StringValueCStr(database));
       #else
-        if (azure == Qtrue) {
-          rb_warn("TinyTds: :azure option is not supported in this version of FreeTDS.\n");
-        }
-        if (contained == Qtrue) {
-          rb_warn("TinyTds: :contained option is not supported in this version of FreeTDS.\n");
-        }
+
+      if (azure == Qtrue) {
+        rb_warn("TinyTds: :azure option is not supported in this version of FreeTDS.\n");
+      }
+
+      if (contained == Qtrue) {
+        rb_warn("TinyTds: :contained option is not supported in this version of FreeTDS.\n");
+      }
+
       #endif
     }
   }
-  if (use_utf16 == Qtrue)  { DBSETLUTF16(cwrap->login, 1); }
-  if (use_utf16 == Qfalse) { DBSETLUTF16(cwrap->login, 0); }
+
+  if (use_utf16 == Qtrue)  {
+    DBSETLUTF16(cwrap->login, 1);
+  }
+
+  if (use_utf16 == Qfalse) {
+    DBSETLUTF16(cwrap->login, 0);
+  }
 
   cwrap->client = dbopen(cwrap->login, StringValueCStr(dataserver));
+
   if (cwrap->client) {
     if (dbtds(cwrap->client) < 11) {
       rb_raise(cTinyTdsError, "connecting with a TDS version older than 7.3!");
@@ -416,31 +492,40 @@ static VALUE rb_tinytds_connect(VALUE self, VALUE opts) {
 
     cwrap->closed = 0;
     cwrap->charset = charset;
-    if (!NIL_P(version))
+
+    if (!NIL_P(version)) {
       dbsetversion(NUM2INT(version));
+    }
+
     if (!NIL_P(timeout)) {
       timeout_string = rb_sprintf("%"PRIsVALUE"", timeout);
+
       if (dbsetopt(cwrap->client, DBSETTIME, StringValueCStr(timeout_string), 0) == FAIL) {
         dbsettime(NUM2INT(timeout));
       }
     }
+
     dbsetuserdata(cwrap->client, (BYTE*)cwrap->userdata);
     dbsetinterrupt(cwrap->client, check_interrupt, handle_interrupt);
     cwrap->userdata->closed = 0;
+
     if (!NIL_P(database) && (azure != Qtrue)) {
       dbuse(cwrap->client, StringValueCStr(database));
     }
+
     transposed_encoding = rb_funcall(cTinyTdsClient, intern_transpose_iconv_encoding, 1, charset);
     cwrap->encoding = rb_enc_find(StringValueCStr(transposed_encoding));
     cwrap->identity_insert_sql = "SELECT CAST(SCOPE_IDENTITY() AS bigint) AS Ident";
   }
+
   return self;
 }
 
 
 // Lib Init
 
-void init_tinytds_client() {
+void init_tinytds_client()
+{
   cTinyTdsClient = rb_define_class_under(mTinyTds, "Client", rb_cObject);
   rb_define_alloc_func(cTinyTdsClient, allocate);
   /* Define TinyTds::Client Public Methods */

--- a/ext/tiny_tds/tiny_tds_ext.c
+++ b/ext/tiny_tds/tiny_tds_ext.c
@@ -6,7 +6,8 @@
 
 VALUE mTinyTds, cTinyTdsError;
 
-void Init_tiny_tds() {
+void Init_tiny_tds()
+{
   mTinyTds      = rb_define_module("TinyTds");
   cTinyTdsError = rb_const_get(mTinyTds, rb_intern("Error"));
   init_tinytds_client();


### PR DESCRIPTION
Closes #565.

This PR introduces a new code formatter for the C and header files. I played around with `clang-format`, but this gives weird results no matter the configuration with these preprocessor statements (long line lengths with macros, unable to align `ifdef` with the code). Artistic style is also not perfect as I do not like having the opening brace for a function on a separate line, but this is really the only complaint.

I added a new task to the `Rakefile` to invoke both formatters at once.