### PR TITLE
Use `TypedData` and CI-related fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,9 +292,12 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "2.7"
-          - "3.0"
-          - "3.1"
+          # currently fails with a dependency resolution 
+          # looking for conflicting packages...
+          # :: installing mingw-w64-x86_64-gcc-libs (15.1.0-8) breaks dependency 'mingw-w64-x86_64-gcc-libs=14.2.0-3' required by mingw-w64-x86_64-gcc
+          # - "2.7"
+          # - "3.0"
+          # - "3.1"
           - "3.2"
           - "3.3"
           - "3.4"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,11 +570,11 @@ jobs:
         shell: bash
         run: bundle exec standardrb
 
-      - name: Check artistic style
-        uses: per1234/artistic-style-action@v1
-        with:
-          options-file-path: "astyle.conf"
-          target-paths: "./ext/"
-          name-patterns: |
-            - '*.c'
-            - '*.h'
+      # - name: Check artistic style
+      #   uses: per1234/artistic-style-action@v1
+      #   with:
+      #     options-file-path: "astyle.conf"
+      #     target-paths: "./ext/"
+      #     name-patterns: |
+      #       - '*.c'
+      #       - '*.h'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## (unreleased)
 
 * Use freetds v1.5.1 and OpenSSL v3.5.0 for Windows and Linux builds.
+* Use `TypedData` in C-Land.
 
 ## 3.2.1
 

--- a/ext/tiny_tds/result.c
+++ b/ext/tiny_tds/result.c
@@ -35,7 +35,6 @@ rb_encoding *binaryEncoding;
 
 
 // Lib Backend (Memory Management)
-
 static void rb_tinytds_result_mark(void *ptr)
 {
   tinytds_result_wrapper *rwrap = (tinytds_result_wrapper *)ptr;
@@ -54,11 +53,26 @@ static void rb_tinytds_result_free(void *ptr)
   xfree(ptr);
 }
 
+static size_t tinytds_result_wrapper_size(const void* data)
+{
+  return sizeof(tinytds_result_wrapper);
+}
+
+const rb_data_type_t tinytds_result_wrapper_type = {
+  .wrap_struct_name = "tinytds_result_wrapper",
+  .function = {
+    .dmark = rb_tinytds_result_mark,
+    .dfree = rb_tinytds_result_free,
+    .dsize = tinytds_result_wrapper_size,
+  },
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
+
 VALUE rb_tinytds_new_result_obj(tinytds_client_wrapper *cwrap)
 {
   VALUE obj;
   tinytds_result_wrapper *rwrap;
-  obj = Data_Make_Struct(cTinyTdsResult, tinytds_result_wrapper, rb_tinytds_result_mark, rb_tinytds_result_free, rwrap);
+  obj = TypedData_Make_Struct(cTinyTdsResult, tinytds_result_wrapper, &tinytds_result_wrapper_type, rwrap);
   rwrap->cwrap = cwrap;
   rwrap->client = cwrap->client;
   rwrap->local_offset = Qnil;

--- a/ext/tiny_tds/result.h
+++ b/ext/tiny_tds/result.h
@@ -19,12 +19,12 @@ typedef struct {
   unsigned long number_of_rows;
 } tinytds_result_wrapper;
 
+extern const rb_data_type_t tinytds_result_wrapper_type;
 
 // Lib Macros
-
 #define GET_RESULT_WRAPPER(self) \
   tinytds_result_wrapper *rwrap; \
-  Data_Get_Struct(self, tinytds_result_wrapper, rwrap)
+  TypedData_Get_Struct(self, tinytds_result_wrapper, &tinytds_result_wrapper_type, rwrap)
 
 
 

--- a/lib/tiny_tds.rb
+++ b/lib/tiny_tds.rb
@@ -10,8 +10,7 @@ require "tiny_tds/gem"
 module TinyTds
   # Is this file part of a fat binary gem with bundled freetds?
   # This path must be enabled by add_dll_directory on Windows.
-  gplat = ::Gem::Platform.local
-  FREETDS_LIB_PATH = Dir[File.expand_path("../ports/#{gplat.cpu}-#{gplat.os}*/{bin,lib}", __dir__)].first
+  FREETDS_LIB_PATH = TinyTds::Gem.ports_bin_and_lib_paths.first
 
   add_dll_path = proc do |path, &block|
     if RUBY_PLATFORM =~ /(mswin|mingw)/i && path

--- a/lib/tiny_tds/bin.rb
+++ b/lib/tiny_tds/bin.rb
@@ -50,7 +50,7 @@ module TinyTds
 
       begin
         ENV["PATH"] = [
-          Gem.ports_bin_paths,
+          Gem.ports_bin_and_lib_paths,
           old_path
         ].flatten.join File::PATH_SEPARATOR
 
@@ -65,7 +65,7 @@ module TinyTds
     end
 
     def find_exe
-      Gem.ports_bin_paths.each do |bin|
+      Gem.ports_bin_and_lib_paths.each do |bin|
         @exts.each do |ext|
           f = File.join bin, "#{name}#{ext}"
           return f if File.exist?(f)

--- a/lib/tiny_tds/gem.rb
+++ b/lib/tiny_tds/gem.rb
@@ -1,5 +1,3 @@
-require "rbconfig"
-
 module TinyTds
   module Gem
     class << self
@@ -11,12 +9,14 @@ module TinyTds
         File.join(root_path, "ports")
       end
 
-      def ports_bin_paths
-        Dir.glob(File.join(ports_root_path, "**", "bin"))
+      def ports_bin_and_lib_paths
+        Dir.glob(File.join(ports_root_path, "#{gem_platform.cpu}-#{gem_platform.os}*", "{bin,lib}"))
       end
 
-      def ports_lib_paths
-        Dir.glob(File.join(ports_root_path, "**", "lib"))
+      private
+
+      def gem_platform
+        ::Gem::Platform.local
       end
     end
   end

--- a/test/bin/restore-from-native-gem.ps1
+++ b/test/bin/restore-from-native-gem.ps1
@@ -4,7 +4,13 @@ $gemToUnpack = "./tiny_tds-$gemVersion-$env:RUBY_ARCHITECTURE.gem"
 Write-Host "Looking to unpack $gemToUnpack"
 gem unpack --target ./tmp "$gemToUnpack"
 
-# Restore precompiled code
+# Restore precompiled code (Gem code)
 $source = (Resolve-Path ".\tmp\tiny_tds-$gemVersion-$env:RUBY_ARCHITECTURE\lib\tiny_tds").Path
 $destination = (Resolve-Path ".\lib\tiny_tds").Path
+Get-ChildItem $source -Recurse -Exclude "*.rb" | Copy-Item -Destination {Join-Path $destination $_.FullName.Substring($source.length)}
+
+# Restore precompiled code (ports)
+$source = (Resolve-Path ".\tmp\tiny_tds-$gemVersion-$env:RUBY_ARCHITECTURE\ports").Path
+New-Item -ItemType Directory -Path ".\ports" -Force
+$destination = (Resolve-Path ".\ports").Path
 Get-ChildItem $source -Recurse -Exclude "*.rb" | Copy-Item -Destination {Join-Path $destination $_.FullName.Substring($source.length)}


### PR DESCRIPTION
Closes #493 

The main intention of this PR is to switch from using `Data` to `TypedData` in C-Land. `Data` is essentially a container object for Ruby to know that we allocate additional memory in C-Land for things outside of Rubys control, e.g. the entire FreeTDS client. `TypedData` gives the Ruby VM a couple more hints about what it deals with. I am sure there is more to that. Anyhow, `Data` is deprecated with Ruby 3.4, so consider this a preparation for adding Ruby 3.5 support.

Then a bunch of CI-related stuff arised, which I also fix in this PR:

- The artistic code style check currently runs endlessly, likely because of a broken download on their side. I'll open a PR there and re-activate the check hopefully soon.
- Installing the `tiny_tds` on Windows without the precompiled stuff fails on 2.7, 3.0 and 3.1 because of a dependency conflict. I am sure it is related to [this bug](https://bugs.ruby-lang.org/issues/21286), but I do not have the time or motivation to investigate how to fix this for these old versions.
- The PowerShell script now correctly restores the `ports` from the precompiled Ruby gem, which lead to another test failure, which I used as a chance to harmonise finding resources in the `ports` directory.