### PR TITLE
v4: Refactor `#new` and `#connect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   * `TinyTds::Result` is now a pure Ruby class
 * `#execute`: Replaced `opts` hash with keyword arguments 
 * Removed `symbolize_keys` and `cache_rows` from `#default_query_options`
+* `TinyTds::Client.new` now accepts keyword arguments instead of a hash
+* Renamed `tds_version` and `tds_version_info` to `server_version` and `server_version_info`.
 
 ## 3.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 * `#execute`: Replaced `opts` hash with keyword arguments 
 * Removed `symbolize_keys` and `cache_rows` from `#default_query_options`
 * `TinyTds::Client.new` now accepts keyword arguments instead of a hash
-* Renamed `tds_version` and `tds_version_info` to `server_version` and `server_version_info`.
+* Renamed `tds_version` and `tds_version_info` to `server_version` and `server_version_info`
+* Separate `#new` and `#connect`
+  * Instead, before running `#do`, `#execute` or `#insert`, `tiny_tds` will check if the connection is active and re-connect if needed.
 
 ## 3.3.0
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Connect to a database.
 client = TinyTds::Client.new username: 'sa', password: 'secret', host: 'mydb.host.net'
 ```
 
-Creating a new client takes a hash of options. For valid iconv encoding options, see the output of `iconv -l`. Only a few have been tested, and are highly recommended to leave blank for the UTF-8 default.
+Creating a new client takes keyword arguments. For valid iconv encoding options, see the output of `iconv -l`. Only a few have been tested, and are highly recommended to leave blank for the UTF-8 default.
 
 * :username - The database server user.
 * :password - The user password.
@@ -106,7 +106,7 @@ Creating a new client takes a hash of options. For valid iconv encoding options,
 * :host - Used if :dataserver blank. Can be an host name or IP.
 * :port - Defaults to 1433. Only used if :host is used.
 * :database - The default database to use.
-* :appname - Short string seen in SQL Servers process/activity window.
+* :app_name - Short string seen in SQL Servers process/activity window.
 * :tds_version - TDS version. Defaults to "7.3".
 * :login_timeout - Seconds to wait for login. Default to 60 seconds.
 * :timeout - Seconds to wait for a response to a SQL command. Default 5 seconds. Timeouts caused by network failure will raise a timeout error 1 second after the configured timeout limit is hit (see [#481](https://github.com/rails-sqlserver/tiny_tds/pull/481) for details).

--- a/lib/tiny_tds/client.rb
+++ b/lib/tiny_tds/client.rb
@@ -1,6 +1,6 @@
 module TinyTds
   class Client
-    attr_reader :app_name, :contained, :database, :dataserver, :encoding, :message_handler, :login_timeout, :password, :port, :tds_version, :timeout, :username, :use_utf16
+    attr_reader :app_name, :charset, :contained, :database, :dataserver, :message_handler, :login_timeout, :password, :port, :tds_version, :timeout, :username, :use_utf16
 
     @default_query_options = {
       as: :hash,
@@ -13,14 +13,6 @@ module TinyTds
     class << self
       attr_reader :default_query_options
 
-      # Most, if not all, iconv encoding names can be found by ruby. Just in case, you can
-      # overide this method to return a string name that Encoding.find would work with. Default
-      # is to return the passed encoding.
-      #
-      def transpose_iconv_encoding(encoding)
-        encoding
-      end
-
       def local_offset
         ::Time.local(2010).utc_offset.to_r / 86_400
       end
@@ -30,7 +22,7 @@ module TinyTds
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
-    def initialize(app_name: "TinyTds", azure: false, contained: false, database: nil, dataserver: nil, encoding: "UTF-8", message_handler: nil, host: nil, login_timeout: 60, password: nil, port: 1433, tds_version: nil, timeout: 5, username: nil, use_utf16: true)
+    def initialize(app_name: "TinyTds", azure: false, charset: "UTF-8", contained: false, database: nil, dataserver: nil, message_handler: nil, host: nil, login_timeout: 60, password: nil, port: 1433, tds_version: nil, timeout: 5, username: nil, use_utf16: true)
       if dataserver.to_s.empty? && host.to_s.empty?
         raise ArgumentError, "missing :host option if no :dataserver given"
       end
@@ -42,9 +34,9 @@ module TinyTds
       end
 
       @app_name = app_name
+      @charset = (charset.nil? || charset.casecmp("utf8").zero?) ? "UTF-8" : charset.upcase
       @database = database
       @dataserver = dataserver || "#{host}:#{port}"
-      @encoding = (encoding.nil? || encoding.casecmp("utf8").zero?) ? "UTF-8" : encoding.upcase
       @login_timeout = login_timeout.to_i
       @password = password if password && password.to_s.strip != ""
       @port = port.to_i

--- a/lib/tiny_tds/client.rb
+++ b/lib/tiny_tds/client.rb
@@ -52,8 +52,6 @@ module TinyTds
       @tds_version = tds_versions_setter(tds_version:)
       @username = parse_username(azure:, host:, username:)
       @use_utf16 = use_utf16.nil? || ["true", "1", "yes"].include?(use_utf16.to_s)
-
-      connect
     end
 
     def tds_73?
@@ -71,7 +69,7 @@ module TinyTds
 
     private
 
-    def parse_username(azure: false, host: nil, username:)
+    def parse_username(username:, azure: false, host: nil)
       return username if username.nil? || !azure
       return username if username.include?("@") && !username.include?("database.windows.net")
       user, domain = username.split("@")

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -45,11 +45,11 @@ class ClientTest < TinyTds::TestCase
       assert_equal "''hello''", @client.escape("'hello'")
     end
 
-    ["CP850", "CP1252", "ISO-8859-1"].each do |encoding|
-      it "allows valid iconv character set - #{encoding}" do
-        client = new_connection(encoding: encoding)
-        assert_equal encoding, client.charset
-        assert_equal Encoding.find(encoding), client.encoding
+    ["CP850", "CP1252", "ISO-8859-1"].each do |charset|
+      it "allows valid iconv character set - #{charset}" do
+        client = new_connection(charset:)
+        assert_equal charset, client.charset
+        assert_equal Encoding.find(charset), client.encoding
       ensure
         client&.close
       end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -26,14 +26,9 @@ class ClientTest < TinyTds::TestCase
       end
     end
 
-    it "has getters for the tds version information (brittle since conf takes precedence)" do
-      if @client.tds_73?
-        assert_equal 11, @client.tds_version
-        assert_equal "DBTDS_7_3 - Microsoft SQL Server 2008", @client.tds_version_info
-      else
-        assert_equal 9, @client.tds_version
-        assert_equal "DBTDS_7_1/DBTDS_8_0 - Microsoft SQL Server 2000", @client.tds_version_info
-      end
+    it "has getters for the server version information (brittle since conf takes precedence)" do
+      assert_equal 11, @client.server_version
+      assert_equal "DBTDS_7_3 - Microsoft SQL Server 2008", @client.server_version_info
     end
 
     it "uses UTF-8 client charset/encoding by default" do
@@ -82,8 +77,7 @@ class ClientTest < TinyTds::TestCase
     end
 
     it "raises TinyTds exception with undefined :dataserver" do
-      options = connection_options login_timeout: 1, dataserver: "DOESNOTEXIST"
-      action = lambda { new_connection(options) }
+      action = lambda { new_connection(login_timeout: 1, dataserver: "DOESNOTEXIST") }
       assert_raise_tinytds_error(action) do |e|
         # Not sure why tese are different.
         if ruby_darwin?
@@ -193,7 +187,7 @@ class ClientTest < TinyTds::TestCase
     it "raises TinyTds exception with wrong :username" do
       skip if ENV["CI"] && sqlserver_azure? # Some issue with db_error_number.
       options = connection_options username: "willnotwork"
-      action = lambda { new_connection(options) }
+      action = lambda { new_connection(**options) }
       assert_raise_tinytds_error(action) do |e|
         assert_equal 18456, e.db_error_number
         assert_equal 14, e.severity

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -10,9 +10,18 @@ class ClientTest < TinyTds::TestCase
       @client = new_connection
     end
 
-    it "must not be closed" do
-      assert !@client.closed?
-      assert @client.active?
+    it "is considered close without a connection" do
+      client = TinyTds::Client.new(**connection_options)
+
+      assert client.closed?
+      assert !client.active?
+    end
+
+    it "returns nil values for server version without a connection" do
+      client = TinyTds::Client.new(**connection_options)
+
+      assert_nil client.server_version
+      assert_nil client.server_version_info
     end
 
     it "allows client connection to be closed" do
@@ -20,10 +29,6 @@ class ClientTest < TinyTds::TestCase
       assert @client.closed?
       assert !@client.active?
       assert @client.dead?
-      action = lambda { @client.execute("SELECT 1 as [one]").each }
-      assert_raise_tinytds_error(action) do |e|
-        assert_match %r{closed connection}i, e.message, "ignore if non-english test run"
-      end
     end
 
     it "has getters for the server version information (brittle since conf takes precedence)" do
@@ -297,16 +302,6 @@ class ClientTest < TinyTds::TestCase
 
         assert_equal(seed, identity)
         assert_client_works(@client)
-      end
-    end
-
-    it "throws an error if client is closed" do
-      @client.close
-      assert @client.closed?
-
-      action = lambda { @client.insert("SELECT 1 as [one]") }
-      assert_raise_tinytds_error(action) do |e|
-        assert_match %r{closed connection}i, e.message
       end
     end
   end

--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -142,9 +142,8 @@ class ResultTest < TinyTds::TestCase
 
     it "works in tandem with the client when needing to find out if client has sql sent and result is canceled or not" do
       # Default state.
-      @client = TinyTds::Client.new(connection_options)
       _(@client.sqlsent?).must_equal false
-      _(@client.canceled?).must_equal false
+      _(@client.canceled?).must_equal true
       # With active result before and after cancel.
       @client.execute(@query1)
       _(@client.sqlsent?).must_equal false

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,6 +43,7 @@ module TinyTds
 
     def new_connection(**options)
       client = TinyTds::Client.new(**connection_options(options))
+
       if sqlserver_azure?
         client.do("SET ANSI_NULLS ON")
         client.do("SET CURSOR_CLOSE_ON_COMMIT OFF")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,8 +41,8 @@ module TinyTds
       client.close if defined?(client) && client.is_a?(TinyTds::Client)
     end
 
-    def new_connection(options = {})
-      client = TinyTds::Client.new(connection_options(options))
+    def new_connection(**options)
+      client = TinyTds::Client.new(**connection_options(options))
       if sqlserver_azure?
         client.do("SET ANSI_NULLS ON")
         client.do("SET CURSOR_CLOSE_ON_COMMIT OFF")
@@ -71,7 +71,7 @@ module TinyTds
        username: username,
        password: password,
        database: ENV["TINYTDS_UNIT_DATABASE"] || "tinytdstest",
-       appname: "TinyTds Dev",
+       app_name: "TinyTds Dev",
        login_timeout: 5,
        timeout: connection_timeout,
        azure: sqlserver_azure?}.merge(options)


### PR DESCRIPTION
This PR refactors a few aspects around `#new` and `#connect` on the `TinyTds::Client`.

First, use keyword arguments instead of an `opts` hash. the list of arguments is quite long, but it allows users to take advantage of pattern matching when passing arguments to initialising a new client. The values are also preserved as instance variables in the `TinyTds::Client`, allowing to implement the second point of this PR.

Second, I removed calling `#connect` from `#new`. Instead, `#connect` is called from either `#do`, `#insert` or `#execute` shortly before the SQL is sent to the server (using `active?`, means a reconnect also happens automatically if the FreeTDS `DBPROCESS` died). I originally wanted that `#connect` has to be called manually, but from a usage-perspective, this is rather cumbersome, especially when we know best when `#connect` has to be called.