### PR TITLE
Support Ruby v4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,7 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
 
     name: install-windows-ucrt
     runs-on: windows-latest
@@ -233,6 +234,7 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
 
     name: test-windows-ucrt
     runs-on: windows-latest
@@ -301,6 +303,7 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
 
     name: install-windows-native
     runs-on: windows-latest
@@ -359,6 +362,7 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
 
         include:
           - platform: x86_64-linux-musl
@@ -420,6 +424,7 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
 
     runs-on: ubuntu-22.04
     steps:
@@ -482,6 +487,7 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
 
     name: install-linux-native
     runs-on: ubuntu-22.04
@@ -528,6 +534,7 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
 
     name: install-macos-m1
     runs-on: macos-14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "2.7"
           - "3.0"
 
     name: install-windows-mingw
@@ -112,7 +111,6 @@ jobs:
           - 2019
           - 2022
         ruby-version:
-          - "2.7"
           - "3.0"
 
     name: test-windows-mingw
@@ -356,7 +354,6 @@ jobs:
           - "aarch64-linux-musl"
 
         ruby-version:
-          - "2.7"
           - "3.0"
           - "3.1"
           - "3.2"
@@ -418,7 +415,6 @@ jobs:
           - 2022
 
         ruby-version:
-          - "2.7"
           - "3.0"
           - "3.1"
           - "3.2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * No longer ship a precompiled Gem for Ruby 2.7
   * This is due to an [upstream change](https://github.com/rake-compiler/rake-compiler-dock/releases/tag/v1.11.0). Users on Windows and Linux on Ruby v2.7 are advised to either upgrade or install FreeTDS manually.
 * Use freetds v1.5.10 and OpenSSL v3.6.0 for Windows and Linux builds.
+* Lower `bigdecimal` requirement to `>= 2.0.0` (was 3.0 only) to allow `bigdecimal` 4.0 on Ruby 4.0. Closes #601.
 
 ## 3.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## (unreleased)
 
+## 3.4.0
+
+* Add Ruby 4.0 to the cross compile list
+
 ## 3.3.0
 
 * Use freetds v1.5.4 and OpenSSL v3.5.2 for Windows and Linux builds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add Ruby 4.0 to the cross compile list
 * No longer ship a precompiled Gem for Ruby 2.7
   * This is due to an [upstream change](https://github.com/rake-compiler/rake-compiler-dock/releases/tag/v1.11.0). Users on Windows and Linux on Ruby v2.7 are advised to either upgrade or install FreeTDS manually.
+* Use freetds v1.5.10 and OpenSSL v3.6.0 for Windows and Linux builds.
 
 ## 3.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 3.4.0
 
 * Add Ruby 4.0 to the cross compile list
+* No longer ship a precompiled Gem for Ruby 2.7
+  * This is due to an [upstream change](https://github.com/rake-compiler/rake-compiler-dock/releases/tag/v1.11.0). Users on Windows and Linux on Ruby v2.7 are advised to either upgrade or install FreeTDS manually.
 
 ## 3.3.0
 

--- a/ext/tiny_tds/extconsts.rb
+++ b/ext/tiny_tds/extconsts.rb
@@ -1,8 +1,8 @@
 ICONV_VERSION = ENV["TINYTDS_ICONV_VERSION"] || "1.18"
 ICONV_SOURCE_URI = "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{ICONV_VERSION}.tar.gz"
 
-OPENSSL_VERSION = ENV["TINYTDS_OPENSSL_VERSION"] || "3.5.2"
+OPENSSL_VERSION = ENV["TINYTDS_OPENSSL_VERSION"] || "3.6.0"
 OPENSSL_SOURCE_URI = "https://www.openssl.org/source/openssl-#{OPENSSL_VERSION}.tar.gz"
 
-FREETDS_VERSION = ENV["TINYTDS_FREETDS_VERSION"] || "1.5.4"
+FREETDS_VERSION = ENV["TINYTDS_FREETDS_VERSION"] || "1.5.10"
 FREETDS_SOURCE_URI = "http://www.freetds.org/files/stable/freetds-#{FREETDS_VERSION}.tar.bz2"

--- a/tasks/native_gem.rake
+++ b/tasks/native_gem.rake
@@ -7,7 +7,7 @@ CrossLibraries.each do |xlib|
 
     RakeCompilerDock.sh <<-EOT, platform: platform
 			bundle install &&
-			rake native:#{platform} pkg/#{SPEC.full_name}-#{platform}.gem MAKEOPTS=-j`nproc` RUBY_CC_VERSION=#{RakeCompilerDock.set_ruby_cc_version("~> 2.7", "~> 3.0", "~> 4.0")} MAKEFLAGS="V=1"
+			rake native:#{platform} pkg/#{SPEC.full_name}-#{platform}.gem MAKEOPTS=-j`nproc` RUBY_CC_VERSION=#{RakeCompilerDock.set_ruby_cc_version("~> 3.0", "~> 4.0")} MAKEFLAGS="V=1"
     EOT
   end
 

--- a/tasks/native_gem.rake
+++ b/tasks/native_gem.rake
@@ -7,7 +7,7 @@ CrossLibraries.each do |xlib|
 
     RakeCompilerDock.sh <<-EOT, platform: platform
 			bundle install &&
-			rake native:#{platform} pkg/#{SPEC.full_name}-#{platform}.gem MAKEOPTS=-j`nproc` RUBY_CC_VERSION=#{RakeCompilerDock.set_ruby_cc_version("~> 2.7", "~> 3.0")} MAKEFLAGS="V=1"
+			rake native:#{platform} pkg/#{SPEC.full_name}-#{platform}.gem MAKEOPTS=-j`nproc` RUBY_CC_VERSION=#{RakeCompilerDock.set_ruby_cc_version("~> 2.7", "~> 3.0", "~> 4.0")} MAKEFLAGS="V=1"
     EOT
   end
 

--- a/test/thread_test.rb
+++ b/test/thread_test.rb
@@ -1,12 +1,9 @@
 require "test_helper"
-require "logger"
 require "benchmark"
 
 class ThreadTest < TinyTds::TestCase
   describe "Threaded SELECT queries" do
     before do
-      @logger = Logger.new $stdout
-      @logger.level = Logger::WARN
       @poolsize = 4
       @numthreads = 10
       @query = "waitfor delay '00:00:01'"
@@ -22,19 +19,14 @@ class ThreadTest < TinyTds::TestCase
       x = Benchmark.realtime do
         threads = []
         @numthreads.times do |i|
-          start = Time.new
           threads << Thread.new do
-            ts = Time.new
             @pool.with { |c| c.execute(@query).do }
-            te = Time.new
-            @logger.info "Thread #{i} finished in #{te - ts} thread seconds, #{te - start} real seconds"
           end
         end
         threads.each { |t| t.join }
       end
       assert x < @numthreads, "#{x} is not faster than #{@numthreads} seconds"
       mintime = (1.0 * @numthreads / @poolsize).ceil
-      @logger.info "#{@numthreads} queries on #{@poolsize} threads: #{x} sec. Minimum time: #{mintime} sec."
       assert x > mintime, "#{x} is not slower than #{mintime} seconds"
     end
 

--- a/tiny_tds.gemspec
+++ b/tiny_tds.gemspec
@@ -28,4 +28,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "connection_pool", "~> 2.2.0"
   s.add_development_dependency "toxiproxy", "~> 2.0.0"
   s.add_development_dependency "standard", "~> 1.31.0"
+  # ostruct can be dropped when updating to Rubocop 1.65+
+  s.add_development_dependency "ostruct"
 end

--- a/tiny_tds.gemspec
+++ b/tiny_tds.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "standard", "~> 1.31.0"
   # ostruct can be dropped when updating to Rubocop 1.65+
   s.add_development_dependency "ostruct"
+  s.add_development_dependency "benchmark"
 end

--- a/tiny_tds.gemspec
+++ b/tiny_tds.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.license = "MIT"
   s.required_ruby_version = ">= 2.7.0"
   s.metadata["msys2_mingw_dependencies"] = "freetds"
-  s.add_dependency "bigdecimal", "~> 3"
+  s.add_dependency "bigdecimal", ">= 2.0.0"
   s.add_development_dependency "mini_portile2", "~> 2.8.0"
   s.add_development_dependency "rake", "~> 13.0.0"
   s.add_development_dependency "rake-compiler", "~> 1.2"

--- a/tiny_tds.gemspec
+++ b/tiny_tds.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mini_portile2", "~> 2.8.0"
   s.add_development_dependency "rake", "~> 13.0.0"
   s.add_development_dependency "rake-compiler", "~> 1.2"
-  s.add_development_dependency "rake-compiler-dock", "~> 1.9.1"
+  s.add_development_dependency "rake-compiler-dock", "~> 1.11.0"
   s.add_development_dependency "minitest", "~> 5.25"
   s.add_development_dependency "minitest-reporters", "~> 1.6.1"
   s.add_development_dependency "connection_pool", "~> 2.2.0"

--- a/tiny_tds.gemspec
+++ b/tiny_tds.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata["msys2_mingw_dependencies"] = "freetds"
   s.add_dependency "bigdecimal", ">= 2.0.0"
   s.add_development_dependency "mini_portile2", "~> 2.8.0"
-  s.add_development_dependency "rake", "~> 13.0.0"
+  s.add_development_dependency "rake", "~> 13.2.0"
   s.add_development_dependency "rake-compiler", "~> 1.2"
   s.add_development_dependency "rake-compiler-dock", "~> 1.11.0"
   s.add_development_dependency "minitest", "~> 5.25"


### PR DESCRIPTION
This PR adds support for Ruby v4.0. There is not really any user-visible code that changed, but couple of things under the hood:

- Update OpenSSL and FreeTDS version.
- Removed the precompiled gem for Ruby v2.7 due to upstream changes.
- Relaxes `bigdecimal` version requirements (Closes #601).
- Adds `ostruct` and `benchmark` to the development, drop `logger`.